### PR TITLE
Make access to large receive buffers atomic

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -77,12 +77,24 @@ void serialEventRun(void)
 #endif
 }
 
-// macro to guard critical sections when needed for large TX buffer sizes
+// Macro to guard critical sections for large transmit buffer sizes
+// Reads from the transmit buffer tail pointer and writes to either head or tail pointer
+// should be atomic in this case
 #if (SERIAL_TX_BUFFER_SIZE>256)
 #define TX_BUFFER_ATOMIC ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
 #else
 #define TX_BUFFER_ATOMIC
 #endif
+
+// Macro to guard critical sections for large receive buffer sizes
+// Reads from the receive buffer head pointer and writes to either head or tail pointer
+// should be atomic in this case
+#if (SERIAL_RX_BUFFER_SIZE>256)
+#define RX_BUFFER_ATOMIC ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
+#else
+#define RX_BUFFER_ATOMIC
+#endif
+
 
 // Actual interrupt handlers //////////////////////////////////////////////////////////////
 
@@ -156,17 +168,27 @@ void HardwareSerial::end()
   cbi(*_ucsrb, UDRIE0);
   
   // clear any received data
+  RX_BUFFER_ATOMIC {
   _rx_buffer_head = _rx_buffer_tail;
+  }
 }
 
 int HardwareSerial::available(void)
 {
-  return ((unsigned int)(SERIAL_RX_BUFFER_SIZE + _rx_buffer_head - _rx_buffer_tail)) % SERIAL_RX_BUFFER_SIZE;
+  rx_buffer_index_t head;
+  RX_BUFFER_ATOMIC {
+    head = _rx_buffer_head;
+  }
+  return ((unsigned int)(SERIAL_RX_BUFFER_SIZE + head - _rx_buffer_tail)) % SERIAL_RX_BUFFER_SIZE;
 }
 
 int HardwareSerial::peek(void)
 {
-  if (_rx_buffer_head == _rx_buffer_tail) {
+  rx_buffer_index_t head;
+  RX_BUFFER_ATOMIC {
+    head = _rx_buffer_head;
+  }
+  if (head == _rx_buffer_tail) {
     return -1;
   } else {
     return _rx_buffer[_rx_buffer_tail];
@@ -175,12 +197,18 @@ int HardwareSerial::peek(void)
 
 int HardwareSerial::read(void)
 {
+  rx_buffer_index_t head;
+  RX_BUFFER_ATOMIC {
+    head = _rx_buffer_head;
+  }
   // if the head isn't ahead of the tail, we don't have any characters
-  if (_rx_buffer_head == _rx_buffer_tail) {
+  if (head == _rx_buffer_tail) {
     return -1;
   } else {
     unsigned char c = _rx_buffer[_rx_buffer_tail];
-    _rx_buffer_tail = (rx_buffer_index_t)(_rx_buffer_tail + 1) % SERIAL_RX_BUFFER_SIZE;
+	RX_BUFFER_ATOMIC {
+      _rx_buffer_tail = (rx_buffer_index_t)(_rx_buffer_tail + 1) % SERIAL_RX_BUFFER_SIZE;
+    }
     return c;
   }
 }


### PR DESCRIPTION
When SERIAL_RX_BUFFER is larger than 256 bytes, its head and tail
pointers are larger than 1 byte. As either pointer may be read by the
interrupt handler _rx_complete_irq() at any time, to avoid reading
inconsistent data all writes should be atomic. In addition, read
accesses to the head pointer should be atomic as this is updated
by the ISR. Read accesses to the tail pointer do not generally need
protection as this is not written by the ISR.

The necessary guards are currently missing, but are provided by this
commit using a new macro RX_BUFFER_ATOMIC to maintain code
readability. This macros expands to ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
only when the receive buffer is larger than 256 bytes.

Thanks to compiler optimisation, the code generated for small
buffers is currently exactly the same as before, so there is no
impact for the normal use case.

Note that there are also atomicity issues when using a large transmit
buffer. This commit does not address those issues.