### PR TITLE
Created flexible SPI transfer functions

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -144,29 +144,14 @@ nano.menu.cpu.atmega328=ATmega328P
 
 nano.menu.cpu.atmega328.upload.maximum_size=30720
 nano.menu.cpu.atmega328.upload.maximum_data_size=2048
-nano.menu.cpu.atmega328.upload.speed=115200
+nano.menu.cpu.atmega328.upload.speed=57600
 
 nano.menu.cpu.atmega328.bootloader.low_fuses=0xFF
 nano.menu.cpu.atmega328.bootloader.high_fuses=0xDA
 nano.menu.cpu.atmega328.bootloader.extended_fuses=0xFD
-nano.menu.cpu.atmega328.bootloader.file=optiboot/optiboot_atmega328.hex
+nano.menu.cpu.atmega328.bootloader.file=atmega/ATmegaBOOT_168_atmega328.hex
 
 nano.menu.cpu.atmega328.build.mcu=atmega328p
-
-## Arduino Nano w/ ATmega328P (old bootloader)
-## --------------------------
-nano.menu.cpu.atmega328old=ATmega328P (Old Bootloader)
-
-nano.menu.cpu.atmega328old.upload.maximum_size=30720
-nano.menu.cpu.atmega328old.upload.maximum_data_size=2048
-nano.menu.cpu.atmega328old.upload.speed=57600
-
-nano.menu.cpu.atmega328old.bootloader.low_fuses=0xFF
-nano.menu.cpu.atmega328old.bootloader.high_fuses=0xDA
-nano.menu.cpu.atmega328old.bootloader.extended_fuses=0xFD
-nano.menu.cpu.atmega328old.bootloader.file=atmega/ATmegaBOOT_168_atmega328.hex
-
-nano.menu.cpu.atmega328old.build.mcu=atmega328p
 
 ## Arduino Nano w/ ATmega168
 ## -------------------------

--- a/cores/arduino/CDC.cpp
+++ b/cores/arduino/CDC.cpp
@@ -34,7 +34,7 @@ typedef struct
 static volatile LineInfo _usbLineInfo = { 57600, 0x00, 0x00, 0x00, 0x00 };
 static volatile int32_t breakValue = -1;
 
-static u8 wdtcsr_save;
+bool _updatedLUFAbootloader = false;
 
 #define WEAK __attribute__ ((weak))
 
@@ -56,11 +56,6 @@ const CDCDescriptor _cdcInterface =
 	D_ENDPOINT(USB_ENDPOINT_OUT(CDC_ENDPOINT_OUT),USB_ENDPOINT_TYPE_BULK,USB_EP_SIZE,0),
 	D_ENDPOINT(USB_ENDPOINT_IN (CDC_ENDPOINT_IN ),USB_ENDPOINT_TYPE_BULK,USB_EP_SIZE,0)
 };
-
-bool isLUFAbootloader()
-{
-	return pgm_read_word(FLASHEND - 1) == NEW_LUFA_SIGNATURE;
-}
 
 int CDC_GetInterface(u8* interfaceNum)
 {
@@ -97,7 +92,10 @@ bool CDC_Setup(USBSetup& setup)
 		if (CDC_SET_CONTROL_LINE_STATE == r)
 		{
 			_usbLineInfo.lineState = setup.wValueL;
+		}
 
+		if (CDC_SET_LINE_CODING == r || CDC_SET_CONTROL_LINE_STATE == r)
+		{
 			// auto-reset into the bootloader is triggered when the port, already 
 			// open at 1200 bps, is closed.  this is the signal to start the watchdog
 			// with a relatively long period so it can finish housekeeping tasks
@@ -111,7 +109,7 @@ bool CDC_Setup(USBSetup& setup)
 #if MAGIC_KEY_POS != (RAMEND-1)
 			// For future boards save the key in the inproblematic RAMEND
 			// Which is reserved for the main() return value (which will never return)
-			if (isLUFAbootloader()) {
+			if (_updatedLUFAbootloader) {
 				// horray, we got a new bootloader!
 				magic_key_pos = (RAMEND-1);
 			}
@@ -121,31 +119,25 @@ bool CDC_Setup(USBSetup& setup)
 			if (1200 == _usbLineInfo.dwDTERate && (_usbLineInfo.lineState & 0x01) == 0)
 			{
 #if MAGIC_KEY_POS != (RAMEND-1)
-				// Backup ram value if its not a newer bootloader and it hasn't already been saved.
+				// Backup ram value if its not a newer bootloader.
 				// This should avoid memory corruption at least a bit, not fully
-				if (magic_key_pos != (RAMEND-1) && *(uint16_t *)magic_key_pos != MAGIC_KEY) {
+				if (magic_key_pos != (RAMEND-1)) {
 					*(uint16_t *)(RAMEND-1) = *(uint16_t *)magic_key_pos;
 				}
 #endif
 				// Store boot key
 				*(uint16_t *)magic_key_pos = MAGIC_KEY;
-				// Save the watchdog state in case the reset is aborted.
-				wdtcsr_save = WDTCSR;
 				wdt_enable(WDTO_120MS);
 			}
-			else if (*(uint16_t *)magic_key_pos == MAGIC_KEY)
+			else
 			{
 				// Most OSs do some intermediate steps when configuring ports and DTR can
 				// twiggle more than once before stabilizing.
-				// To avoid spurious resets we set the watchdog to 120ms and eventually
+				// To avoid spurious resets we set the watchdog to 250ms and eventually
 				// cancel if DTR goes back high.
-				// Cancellation is only done if an auto-reset was started, which is
-				// indicated by the magic key having been set.
 
+				wdt_disable();
 				wdt_reset();
-				// Restore the watchdog state in case the sketch was using it.
-				WDTCSR |= (1<<WDCE) | (1<<WDE);
-				WDTCSR = wdtcsr_save;
 #if MAGIC_KEY_POS != (RAMEND-1)
 				// Restore backed up (old bootloader) magic key data
 				if (magic_key_pos != (RAMEND-1)) {

--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -26,7 +26,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <inttypes.h>
-#include <util/atomic.h>
 #include "Arduino.h"
 
 #include "HardwareSerial.h"
@@ -77,13 +76,6 @@ void serialEventRun(void)
 #endif
 }
 
-// macro to guard critical sections when needed for large TX buffer sizes
-#if (SERIAL_TX_BUFFER_SIZE>256)
-#define TX_BUFFER_ATOMIC ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
-#else
-#define TX_BUFFER_ATOMIC
-#endif
-
 // Actual interrupt handlers //////////////////////////////////////////////////////////////
 
 void HardwareSerial::_tx_udr_empty_irq(void)
@@ -97,14 +89,8 @@ void HardwareSerial::_tx_udr_empty_irq(void)
 
   // clear the TXC bit -- "can be cleared by writing a one to its bit
   // location". This makes sure flush() won't return until the bytes
-  // actually got written. Other r/w bits are preserved, and zeroes
-  // written to the rest.
-
-#ifdef MPCM0
-  *_ucsra = ((*_ucsra) & ((1 << U2X0) | (1 << MPCM0))) | (1 << TXC0);
-#else
-  *_ucsra = ((*_ucsra) & ((1 << U2X0) | (1 << TXC0)));
-#endif
+  // actually got written
+  sbi(*_ucsra, TXC0);
 
   if (_tx_buffer_head == _tx_buffer_tail) {
     // Buffer empty, so disable interrupts
@@ -191,13 +177,15 @@ int HardwareSerial::read(void)
 
 int HardwareSerial::availableForWrite(void)
 {
-  tx_buffer_index_t head;
-  tx_buffer_index_t tail;
-
-  TX_BUFFER_ATOMIC {
-    head = _tx_buffer_head;
-    tail = _tx_buffer_tail;
-  }
+#if (SERIAL_TX_BUFFER_SIZE>256)
+  uint8_t oldSREG = SREG;
+  cli();
+#endif
+  tx_buffer_index_t head = _tx_buffer_head;
+  tx_buffer_index_t tail = _tx_buffer_tail;
+#if (SERIAL_TX_BUFFER_SIZE>256)
+  SREG = oldSREG;
+#endif
   if (head >= tail) return SERIAL_TX_BUFFER_SIZE - 1 - head + tail;
   return tail - head - 1;
 }
@@ -230,22 +218,8 @@ size_t HardwareSerial::write(uint8_t c)
   // significantly improve the effective datarate at high (>
   // 500kbit/s) bitrates, where interrupt overhead becomes a slowdown.
   if (_tx_buffer_head == _tx_buffer_tail && bit_is_set(*_ucsra, UDRE0)) {
-    // If TXC is cleared before writing UDR and the previous byte
-    // completes before writing to UDR, TXC will be set but a byte
-    // is still being transmitted causing flush() to return too soon.
-    // So writing UDR must happen first.
-    // Writing UDR and clearing TC must be done atomically, otherwise
-    // interrupts might delay the TXC clear so the byte written to UDR
-    // is transmitted (setting TXC) before clearing TXC. Then TXC will
-    // be cleared when no bytes are left, causing flush() to hang
-    ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-      *_udr = c;
-#ifdef MPCM0
-      *_ucsra = ((*_ucsra) & ((1 << U2X0) | (1 << MPCM0))) | (1 << TXC0);
-#else
-      *_ucsra = ((*_ucsra) & ((1 << U2X0) | (1 << TXC0)));
-#endif
-    }
+    *_udr = c;
+    sbi(*_ucsra, TXC0);
     return 1;
   }
   tx_buffer_index_t i = (_tx_buffer_head + 1) % SERIAL_TX_BUFFER_SIZE;
@@ -266,14 +240,9 @@ size_t HardwareSerial::write(uint8_t c)
   }
 
   _tx_buffer[_tx_buffer_head] = c;
-
-  // make atomic to prevent execution of ISR between setting the
-  // head pointer and setting the interrupt flag resulting in buffer
-  // retransmission
-  ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-    _tx_buffer_head = i;
-    sbi(*_ucsrb, UDRIE0);
-  }
+  _tx_buffer_head = i;
+	
+  sbi(*_ucsrb, UDRIE0);
   
   return 1;
 }

--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -35,6 +35,7 @@ extern const u16 STRING_LANGUAGE[] PROGMEM;
 extern const u8 STRING_PRODUCT[] PROGMEM;
 extern const u8 STRING_MANUFACTURER[] PROGMEM;
 extern const DeviceDescriptor USB_DeviceDescriptorIAD PROGMEM;
+extern bool _updatedLUFAbootloader;
 
 const u16 STRING_LANGUAGE[2] = {
 	(3<<8) | (2+2),
@@ -818,6 +819,12 @@ void USBDevice_::attach()
 	UDIEN = (1<<EORSTE) | (1<<SOFE) | (1<<SUSPE);	// Enable interrupts for EOR (End of Reset), SOF (start of frame) and SUSPEND
 	
 	TX_RX_LED_INIT;
+
+#if MAGIC_KEY_POS != (RAMEND-1)
+	if (pgm_read_word(FLASHEND - 1) == NEW_LUFA_SIGNATURE) {
+		_updatedLUFAbootloader = true;
+	}
+#endif
 }
 
 void USBDevice_::detach()

--- a/cores/arduino/USBCore.h
+++ b/cores/arduino/USBCore.h
@@ -285,7 +285,8 @@ typedef struct
 // Old Caterina bootloader places the MAGIC key into unsafe RAM locations (it can be rewritten
 // by the running sketch before to actual reboot).
 // Newer bootloaders, recognizable by the LUFA "signature" at the end of the flash, can handle both
-// the usafe and the safe location.
+// the usafe and the safe location. Check once (in USBCore.cpp) if the bootloader in new, then set the global
+// _updatedLUFAbootloader variable to true/false and place the magic key consequently
 #ifndef MAGIC_KEY
 #define MAGIC_KEY 0x7777
 #endif

--- a/cores/arduino/wiring.c
+++ b/cores/arduino/wiring.c
@@ -39,7 +39,7 @@ volatile unsigned long timer0_overflow_count = 0;
 volatile unsigned long timer0_millis = 0;
 static unsigned char timer0_fract = 0;
 
-#if defined(TIM0_OVF_vect)
+#if defined(__AVR_ATtiny24__) || defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__)
 ISR(TIM0_OVF_vect)
 #else
 ISR(TIMER0_OVF_vect)

--- a/libraries/SPI/examples/FlexibleTransfers/FlexibleTransfers.ino
+++ b/libraries/SPI/examples/FlexibleTransfers/FlexibleTransfers.ino
@@ -1,11 +1,59 @@
+/*
+ * This is an example of usage of the new flexible transfer functions
+ * 
+ * Author: Owen Lyke
+ * July 2018
+ */
+
 #include <SPI.h>
+
+uint8_t txBuffer[5] = {0xC0, 0xAA, 0xFF, 0x55, 0x03};   // A unique pattern that can be identified on a logic analyzer
+uint8_t rxBuffer[5] = {0xFA, 0xFB, 0xFC, 0xFD, 0xFE};   // A unique pattern that can be identified on a logic analyzer
+
+uint8_t csPin = 4;                                      // CS helps sync a logic analyzer
 
 void setup() {
   // put your setup code here, to run once:
+  Serial.begin(9600);
+  while(!Serial){};
 
+  pinMode(csPin, OUTPUT);
+  digitalWrite(csPin, HIGH);
+  
+  SPI.begin();
+  
 }
 
 void loop() {
   // put your main code here, to run repeatedly:
 
+  digitalWrite(csPin, LOW);
+  SPI.beginTransaction(SPISettings(1000000, MSBFIRST, SPI_MODE3));
+
+  /* Because SPI hardware is based on transfers data must be sent 
+   *  out as it is being received. In some cases only the received 
+   *  data is needed. In this case it can be reassuring, or even 
+   *  necessary, to know exactly what will be on the MOSI line at
+   *  that time. 
+   *  
+   *  The transferIn(bufIn, size, junk) method allows you to specify a byte to tranmit
+   *  while receiving into a buffer.
+   */
+  SPI.transferIn(rxBuffer, 2, 0xC3);
+  delay(1);
+  
+  /* Again, SPI hardware is based on transfers. The normal 
+   *  transfer() method replaces the transmit buffer contents
+   *  with whatever was read on the MISO line. This is 
+   *  undesireable when hardware SPI is used to control devices
+   *  such as addressable LEDs and OLED displays. 
+   *  
+   *  The transferOut(bufOut, size) method discards any data 
+   *  that was received on the MISO line, preserving the contents 
+   *  of bufOut.
+   */
+  SPI.transferOut(rxBuffer, 5);
+  SPI.endTransaction();
+  digitalWrite(csPin, HIGH);
+  delay(5);
 }

--- a/libraries/SPI/examples/FlexibleTransfers/FlexibleTransfers.ino
+++ b/libraries/SPI/examples/FlexibleTransfers/FlexibleTransfers.ino
@@ -1,0 +1,11 @@
+#include <SPI.h>
+
+void setup() {
+  // put your setup code here, to run once:
+
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+
+}

--- a/libraries/SPI/keywords.txt
+++ b/libraries/SPI/keywords.txt
@@ -14,6 +14,8 @@ SPI	KEYWORD1
 begin	KEYWORD2
 end	KEYWORD2
 transfer	KEYWORD2
+transferIn	KEYWORD2
+transferOut	KEYWORD2
 setBitOrder	KEYWORD2
 setDataMode	KEYWORD2
 setClockDivider	KEYWORD2

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -260,19 +260,19 @@ public:
     uint8_t *p = (uint8_t *)bufOut;
     SPDR = *p;
     while (--count > 0) {
-      uint8_t out = *(p + 1);
+      uint8_t out = *(p++ + 1);
       while (!(SPSR & _BV(SPIF))) ;
       // uint8_t in = SPDR;
       SPDR = out;
       // *p++ = in;
     }
     while (!(SPSR & _BV(SPIF))) ;
-    *p = SPDR;
+    // *p = SPDR;
   }
   inline static void transferIn(void *bufIn, size_t count, uint8_t junk) {
     if (count == 0) return;
     uint8_t *p = (uint8_t *)bufIn;
-    SPDR = *p;
+    SPDR = junk;
     while (--count > 0) {
       // uint8_t out = *(p + 1);
       while (!(SPSR & _BV(SPIF))) ;

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -255,6 +255,34 @@ public:
     while (!(SPSR & _BV(SPIF))) ;
     *p = SPDR;
   }
+  inline static void transferOut(void *bufOut, size_t count) {
+    if (count == 0) return;
+    uint8_t *p = (uint8_t *)bufOut;
+    SPDR = *p;
+    while (--count > 0) {
+      uint8_t out = *(p + 1);
+      while (!(SPSR & _BV(SPIF))) ;
+      // uint8_t in = SPDR;
+      SPDR = out;
+      // *p++ = in;
+    }
+    while (!(SPSR & _BV(SPIF))) ;
+    *p = SPDR;
+  }
+  inline static void transferIn(void *bufIn, size_t count, uint8_t junk) {
+    if (count == 0) return;
+    uint8_t *p = (uint8_t *)bufIn;
+    SPDR = *p;
+    while (--count > 0) {
+      // uint8_t out = *(p + 1);
+      while (!(SPSR & _BV(SPIF))) ;
+      uint8_t in = SPDR;
+      SPDR = junk;
+      *p++ = in;
+    }
+    while (!(SPSR & _BV(SPIF))) ;
+    *p = SPDR;
+  }
   // After performing a group of transfers and releasing the chip select
   // signal, this function allows others to access the SPI bus
   inline static void endTransaction(void) {

--- a/libraries/Wire/examples/digital_potentiometer/digital_potentiometer.ino
+++ b/libraries/Wire/examples/digital_potentiometer/digital_potentiometer.ino
@@ -9,6 +9,8 @@
 
 // This example code is in the public domain.
 
+// This example code is in the public domain.
+
 
 #include <Wire.h>
 

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -17,7 +17,6 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  
   Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
-  Modified 2017 by Chuck Todd (ctodd@cableone.net) to correct Unconfigured Slave Mode reboot
 */
 
 extern "C" {
@@ -61,14 +60,14 @@ void TwoWire::begin(void)
   txBufferLength = 0;
 
   twi_init();
-  twi_attachSlaveTxEvent(onRequestService); // default callback must exist
-  twi_attachSlaveRxEvent(onReceiveService); // default callback must exist
 }
 
 void TwoWire::begin(uint8_t address)
 {
-  begin();
   twi_setAddress(address);
+  twi_attachSlaveTxEvent(onRequestService);
+  twi_attachSlaveRxEvent(onReceiveService);
+  begin();
 }
 
 void TwoWire::begin(int address)

--- a/platform.txt
+++ b/platform.txt
@@ -6,7 +6,7 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5-3rd-party-Hardware-specification
 
 name=Arduino AVR Boards
-version=1.6.22
+version=1.6.20
 
 # AVR compile variables
 # ---------------------

--- a/programmers.txt
+++ b/programmers.txt
@@ -43,9 +43,9 @@ parallel.program.extra_params=-F
 
 arduinoasisp.name=Arduino as ISP
 arduinoasisp.communication=serial
-arduinoasisp.protocol=arduino
+arduinoasisp.protocol=stk500v1
 arduinoasisp.speed=19200
-arduinoasisp.program.protocol=arduino
+arduinoasisp.program.protocol=stk500v1
 arduinoasisp.program.speed=19200
 arduinoasisp.program.tool=avrdude
 arduinoasisp.program.extra_params=-P{serial.port} -b{program.speed}


### PR DESCRIPTION
This is a small update for the core SPI library for the UNO. The concepts can be applied to other cores so that ultimately these functions could be ubiquitous.

Added:
- transferIn(void *bufIn, size_t count, uint8_t junk)
- transferOut(void *bufOut, size_t count)

transferIn allows reading data with a known output to the MOSI line without needing to pre-define the entire buffer.

transferOut preserves the content of a buffer when sending it, discarding what comes in through the MISO line. This is useful in using hardware SPI for control of addressable LEDs, OLED panels, etc...

Also had to update the surrounding directory for compatibility with Arduino IDE 1.8.5
