### PR TITLE
Fix stk500v2 READ_EEPROM to properly read EEPROM

### DIFF
--- a/bootloaders/stk500v2/stk500boot.c
+++ b/bootloaders/stk500v2/stk500boot.c
@@ -1063,10 +1063,13 @@ int main(void)
 						else
 						{
 							/* Read EEPROM */
+							uint16_t ii = address >> 1;
 							do {
-								EEARL	=	address;			// Setup EEPROM address
-								EEARH	=	((address >> 8));
-								address++;					// Select next EEPROM byte
+								EEARL	=	ii;			// Setup EEPROM address
+								EEARH	=	((ii >> 8));
+								address += 2; // Select next EEPROM byte
+								ii++;
+
 								EECR	|=	(1<<EERE);			// Read EEPROM
 								*p++	=	EEDR;				// Send EEPROM data
 								size--;


### PR DESCRIPTION

Fix for  #23.  READ_EEPROM was not reading EEPROM correctly, assuming each EEPROM address points to a 16bit  location, but reading only 8 bit, so it would return every other byte.

This fixes it to read every byte correctly.

(This was originally submitted as https://github.com/arduino/Arduino/pull/6456 before the code was split off of that repo. Re-submitting so that it goes against right repo)