### PR TITLE
fix 6 year old bug in ipaddress.h

### DIFF
--- a/cores/arduino/IPAddress.cpp
+++ b/cores/arduino/IPAddress.cpp
@@ -112,3 +112,4 @@ size_t IPAddress::printTo(Print& p) const
     return n;
 }
 
+const IPAddress INADDR_NONE(0, 0, 0, 0);

--- a/cores/arduino/IPAddress.h
+++ b/cores/arduino/IPAddress.h
@@ -73,6 +73,6 @@ public:
     friend class DNSClient;
 };
 
-const IPAddress INADDR_NONE(0,0,0,0);
+extern const IPAddress INADDR_NONE;
 
 #endif


### PR DESCRIPTION
This bug causes multiple sram usage. Now only one instance should be in sram.

fix https://github.com/arduino/Arduino/issues/1007