### PR TITLE
Add `bitToggle` macro to complement `bitSet` etc

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -111,6 +111,7 @@ void yield(void);
 #define bitRead(value, bit) (((value) >> (bit)) & 0x01)
 #define bitSet(value, bit) ((value) |= (1UL << (bit)))
 #define bitClear(value, bit) ((value) &= ~(1UL << (bit)))
+#define bitToggle(value, bit) ((value) ^= (1UL << (bit)))
 #define bitWrite(value, bit, bitvalue) (bitvalue ? bitSet(value, bit) : bitClear(value, bit))
 
 // avr-libc defines _NOP() since 1.6.2


### PR DESCRIPTION
Currently there are only `bitSet`, `bitClear` and `bitWrite` to write to a bitfield. It is also useful to toggle a bit. Currently toggling would involve a combination of `bitRead` and `bitWrite` but this is not really necessary. Hence my humble submission.

Thank you for Arduino (which I'm using via [KeyboardIO](https://github.com/keyboardio))! 💐