### PR TITLE
Add placement new operator

### DIFF
--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -27,6 +27,7 @@ void *operator new[](size_t size) {
 }
 
 void * operator new(size_t size, void * ptr) {
+  (void)size;
   return ptr;
 }
 

--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -26,6 +26,10 @@ void *operator new[](size_t size) {
   return malloc(size);
 }
 
+void * operator new(size_t size, void * ptr) {
+  return ptr;
+}
+
 void operator delete(void * ptr) {
   free(ptr);
 }

--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -26,7 +26,7 @@ void *operator new[](size_t size) {
   return malloc(size);
 }
 
-void * operator new(size_t size, void * ptr) {
+void * operator new(size_t size, void * ptr) noexcept {
   (void)size;
   return ptr;
 }

--- a/cores/arduino/new.h
+++ b/cores/arduino/new.h
@@ -23,6 +23,7 @@
 
 void * operator new(size_t size);
 void * operator new[](size_t size);
+void * operator new(size_t size, void * ptr);
 void operator delete(void * ptr);
 void operator delete[](void * ptr);
 

--- a/cores/arduino/new.h
+++ b/cores/arduino/new.h
@@ -23,7 +23,7 @@
 
 void * operator new(size_t size);
 void * operator new[](size_t size);
-void * operator new(size_t size, void * ptr);
+void * operator new(size_t size, void * ptr) noexcept;
 void operator delete(void * ptr);
 void operator delete[](void * ptr);
 


### PR DESCRIPTION
This adds the missing placement new operator.
The placement new operator is especially useful when working with raw data buffers (often used when implementing data structures to avoid requiring a default constructor).

More information about placement new can be found here:
https://en.cppreference.com/w/cpp/language/new#Placement_new