### PR TITLE
Fix compiler warnings about ignored 'const' in EEPROM.h

### DIFF
--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -40,7 +40,7 @@ struct EERef{
     
     //Access/read members.
     uint8_t operator*() const            { return eeprom_read_byte( (uint8_t*) index ); }
-    operator const uint8_t() const       { return **this; }
+    operator uint8_t() const             { return **this; }
     
     //Assignment/write members.
     EERef &operator=( const EERef &ref ) { return *this = *ref; }
@@ -89,7 +89,7 @@ struct EEPtr{
     EEPtr( const int index )
         : index( index )                {}
         
-    operator const int() const          { return index; }
+    operator int() const                { return index; }
     EEPtr &operator=( int in )          { return index = in, *this; }
     
     //Iterator functionality.


### PR DESCRIPTION
Fix for Issue #36 