### PR TITLE
Treat narrowing conversion as warning, not error

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -25,7 +25,7 @@ compiler.c.elf.flags={compiler.warning_flags} -Os -g -flto -fuse-linker-plugin -
 compiler.c.elf.cmd=avr-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -flto -MMD
 compiler.cpp.cmd=avr-g++
-compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -MMD -flto
+compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++11 -fpermissive -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -Wno-error=narrowing -MMD -flto
 compiler.ar.cmd=avr-gcc-ar
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=avr-objcopy


### PR DESCRIPTION
Fix for https://github.com/arduino/Arduino/issues/7944

Before the upgrade to gcc 5.4, this was treated as a non-fatal warning (when warnings are enabled).  Now some libraries fail to compile.  This simply restores the gcc 4.8 & 4.9 behavior.