### PR TITLE
Remove historic Arduino 0012 workaround in SoftwareSerial

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.h
@@ -111,13 +111,4 @@ public:
   static inline void handle_interrupt() __attribute__((__always_inline__));
 };
 
-// Arduino 0012 workaround
-#undef int
-#undef char
-#undef long
-#undef byte
-#undef float
-#undef abs
-#undef round
-
 #endif


### PR DESCRIPTION
Remove `#undef`s in SoftwareSerial.h marked as _Arduino 0012 workaround_ that broke several macros, including `abs`.

Fixes #30.
