### PR TITLE
Add USBDevice.isSuspended()

### DIFF
--- a/cores/arduino/USBAPI.h
+++ b/cores/arduino/USBAPI.h
@@ -65,6 +65,8 @@ public:
 	void detach();	// Serial port goes down too...
 	void poll();
 	bool wakeupHost(); // returns false, when wakeup cannot be processed
+
+	bool isSuspended();
 };
 extern USBDevice_ USBDevice;
 

--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -855,4 +855,10 @@ bool USBDevice_::wakeupHost()
 	return false;
 }
 
+bool USBDevice_::isSuspended()
+{
+	return (_usbSuspendState & (1 << SUSPI));
+}
+
+
 #endif /* if defined(USBCON) */


### PR DESCRIPTION
Based on code originally by Rob van der Veer (from arduino/Arduino#4241), this adds `USBDevice.isSuspended()`, so user sketches can run custom code in their `loop` methods after checking if the device is suspended or not.

This is a port of arduino/Arduino#6964 to `ArduinoCore-avr`. Please let me know if there's anything you want changed, and I'll update the pull request accordingly.