### PR TITLE
Add ATmega32U4-compatible Arduino as ISP programmer

### DIFF
--- a/programmers.txt
+++ b/programmers.txt
@@ -43,9 +43,9 @@ parallel.program.extra_params=-F
 
 arduinoasisp.name=Arduino as ISP
 arduinoasisp.communication=serial
-arduinoasisp.protocol=arduino
+arduinoasisp.protocol=stk500v1
 arduinoasisp.speed=19200
-arduinoasisp.program.protocol=arduino
+arduinoasisp.program.protocol=stk500v1
 arduinoasisp.program.speed=19200
 arduinoasisp.program.tool=avrdude
 arduinoasisp.program.extra_params=-P{serial.port} -b{program.speed}

--- a/programmers.txt
+++ b/programmers.txt
@@ -50,6 +50,15 @@ arduinoasisp.program.speed=19200
 arduinoasisp.program.tool=avrdude
 arduinoasisp.program.extra_params=-P{serial.port} -b{program.speed}
 
+arduinoasispatmega32u4.name=Arduino as ISP (ATmega32U4)
+arduinoasispatmega32u4.communication=serial
+arduinoasispatmega32u4.protocol=arduino
+arduinoasispatmega32u4.speed=19200
+arduinoasispatmega32u4.program.protocol=arduino
+arduinoasispatmega32u4.program.speed=19200
+arduinoasispatmega32u4.program.tool=avrdude
+arduinoasispatmega32u4.program.extra_params=-P{serial.port} -b{program.speed}
+
 usbGemma.name=Arduino Gemma
 usbGemma.protocol=arduinogemma
 usbGemma.program.tool=avrdude


### PR DESCRIPTION
Use of the `stk500v1` protocol for Arduino as ISP does not work with native USB boards on Windows. The `arduino` protocol does (see https://github.com/arduino/Arduino/issues/1182#issue-9477400).

However, the `arduino` protocol makes it more likely that boards with an external USB interface chip will require the auto-reset circuitry to be disabled to allow them to be used as Arduino as ISP. That adds extra complexity to a process already difficult for the average Arduino user.

For this reason, this pull request does the following:
- Revert the [previous commit changing the Arduino as ISP programmer to use the `arduino` protocol](https://github.com/arduino/ArduinoCore-avr/commit/b084848f2eaf9ccb3ac9a64ac5492d91df4706bf). This restores the Arduino as ISP programmer to maximum compatibility with boards using an external USB interface.
- Add a new programmer using the `arduino` protocol specifically for using native USB boards as Arduino as ISP.

I'm not sure what the most appropriate name for the new programmer is. I went with "Arduino as ISP (ATmega32U4)" and the ID `arduinoasispatmega32u4` but I'm happy to modify this PR if something else is preferred.

Approved at https://github.com/arduino/Arduino/issues/8032#issuecomment-448520230

- Fixes https://github.com/arduino/Arduino/issues/1182 (though note some more advanced fixes are also discussed in that thread)
- Fixes https://github.com/arduino/Arduino/issues/8032