### PR TITLE
Support extra parameter on `attachInterrupt()`

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -148,6 +148,7 @@ void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val);
 uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder);
 
 void attachInterrupt(uint8_t, void (*)(void), int mode);
+void attachInterruptParam(uint8_t, void (*)(void*), int mode, void* param);
 void detachInterrupt(uint8_t);
 
 void setup(void);

--- a/cores/arduino/wiring_private.h
+++ b/cores/arduino/wiring_private.h
@@ -63,8 +63,6 @@ uint32_t countPulseASM(volatile uint8_t *port, uint8_t bit, uint8_t stateMask, u
 #define EXTERNAL_NUM_INTERRUPTS 2
 #endif
 
-typedef void (*voidFuncPtr)(void);
-
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
When writing an arduino library, it is difficult to connect interrupt handlers with the component instance that should be notified.

In C, the common pattern to fix this is to specifying a `void*` parameter with the callback, where the listener can store any context necessary.

This patch adds the new function `attachInterruptParam()` to implement this pattern.


This PR was originally developed on https://github.com/arduino/Arduino/pull/4519, and it's contains lengthy discussions about the implementation strategies and overhead.

A similar PR is available for SAM devices: https://github.com/arduino/ArduinoCore-sam/pull/44

Overhead summary:
- CPU: it needs 2 extra instructions (4 cycles) before the user funcion is called.
- RAM: intFuncParam takes `2*EXTERNAL_NUM_INTERRUPTS` extra bytes (10 bytes of RAM on Arduino Pro Micro)
- Flash: Adds 56 bytes of Flash on Arduino Pro Micro

I do believe these are very acceptable values for a very useful feature.