### PR TITLE
stk500v2 return from watchdog reset fix

### DIFF
--- a/bootloaders/stk500v2/stk500boot.c
+++ b/bootloaders/stk500v2/stk500boot.c
@@ -523,10 +523,6 @@ uint32_t count = 0;
 	return UART_DATA_REG;
 }
 
-//*	for watch dog timer startup
-void (*app_start)(void) = 0x0000;
-
-
 //*****************************************************************************
 int main(void)
 {
@@ -572,7 +568,11 @@ int main(void)
 	// check if WDT generated the reset, if so, go straight to app
 	if (mcuStatusReg & _BV(WDRF))
 	{
-		app_start();
+		asm volatile(
+			"clr	r30		\n\t"
+			"clr	r31		\n\t"
+			"ijmp	\n\t"
+		);
 	}
 	//************************************************************************
 #endif


### PR DESCRIPTION
For some reason, calling `app_start` is not working at least with avr-gcc 4.9.2
So I replaced it with actually working asm sequence taken from the end of the bootloader.