### PR TITLE
Interrupt ordering for 32u2 and 16u2 MCU

### DIFF
--- a/cores/arduino/WInterrupts.c
+++ b/cores/arduino/WInterrupts.c
@@ -102,7 +102,7 @@ void attachInterrupt(uint8_t interruptNum, void (*userFunc)(void), int mode) {
         EICRB = (EICRB & ~((1<<ISC60) | (1<<ISC61))) | (mode << ISC60);
         EIMSK |= (1<<INT6);
         break;
-#elif defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__)
+#elif defined(__AVR_AT90USB82__) || defined(__AVR_AT90USB162__) || defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega8U2__)
     case 0:
       EICRA = (EICRA & ~((1 << ISC00) | (1 << ISC01))) | (mode << ISC00);
       EIMSK |= (1 << INT0);
@@ -238,7 +238,7 @@ void detachInterrupt(uint8_t interruptNum) {
     case 4:
         EIMSK &= ~(1<<INT6);
         break;
-#elif defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__)
+#elif defined(__AVR_AT90USB82__) || defined(__AVR_AT90USB162__) || defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega8U2__)
     case 0:
       EIMSK &= ~(1 << INT0);
       break;
@@ -345,7 +345,7 @@ IMPLEMENT_ISR(INT2_vect, EXTERNAL_INT_2)
 IMPLEMENT_ISR(INT3_vect, EXTERNAL_INT_3)
 IMPLEMENT_ISR(INT6_vect, EXTERNAL_INT_4)
 
-#elif defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__)
+#elif defined(__AVR_AT90USB82__) || defined(__AVR_AT90USB162__) || defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__) || defined(__AVR_ATmega8U2__)
 
 IMPLEMENT_ISR(INT0_vect, EXTERNAL_INT_0)
 IMPLEMENT_ISR(INT1_vect, EXTERNAL_INT_1)

--- a/cores/arduino/WInterrupts.c
+++ b/cores/arduino/WInterrupts.c
@@ -102,6 +102,39 @@ void attachInterrupt(uint8_t interruptNum, void (*userFunc)(void), int mode) {
         EICRB = (EICRB & ~((1<<ISC60) | (1<<ISC61))) | (mode << ISC60);
         EIMSK |= (1<<INT6);
         break;
+#elif defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__)
+    case 0:
+      EICRA = (EICRA & ~((1 << ISC00) | (1 << ISC01))) | (mode << ISC00);
+      EIMSK |= (1 << INT0);
+      break;
+    case 1:
+      EICRA = (EICRA & ~((1 << ISC10) | (1 << ISC11))) | (mode << ISC10);
+      EIMSK |= (1 << INT1);
+      break;
+    case 2:
+      EICRA = (EICRA & ~((1 << ISC20) | (1 << ISC21))) | (mode << ISC20);
+      EIMSK |= (1 << INT2);
+      break;
+    case 3:
+      EICRA = (EICRA & ~((1 << ISC30) | (1 << ISC31))) | (mode << ISC30);
+      EIMSK |= (1 << INT3);
+      break;
+    case 4:
+      EICRB = (EICRB & ~((1 << ISC40) | (1 << ISC41))) | (mode << ISC40);
+      EIMSK |= (1 << INT4);
+      break;
+    case 5:
+      EICRB = (EICRB & ~((1 << ISC50) | (1 << ISC51))) | (mode << ISC50);
+      EIMSK |= (1 << INT5);
+      break;
+    case 6:
+      EICRB = (EICRB & ~((1 << ISC60) | (1 << ISC61))) | (mode << ISC60);
+      EIMSK |= (1 << INT6);
+      break;
+    case 7:
+      EICRB = (EICRB & ~((1 << ISC70) | (1 << ISC71))) | (mode << ISC70);
+      EIMSK |= (1 << INT7);
+      break;
 #elif defined(EICRA) && defined(EICRB) && defined(EIMSK)
     case 2:
       EICRA = (EICRA & ~((1 << ISC00) | (1 << ISC01))) | (mode << ISC00);
@@ -204,7 +237,32 @@ void detachInterrupt(uint8_t interruptNum) {
         break;	
     case 4:
         EIMSK &= ~(1<<INT6);
-        break;	
+        break;
+#elif defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__)
+    case 0:
+      EIMSK &= ~(1 << INT0);
+      break;
+    case 1:
+      EIMSK &= ~(1 << INT1);
+      break;
+    case 2:
+      EIMSK &= ~(1 << INT2);
+      break;
+    case 3:
+      EIMSK &= ~(1 << INT3);
+      break;
+    case 4:
+      EIMSK &= ~(1 << INT4);
+      break;
+    case 5:
+      EIMSK &= ~(1 << INT5);
+      break;
+    case 6:
+      EIMSK &= ~(1 << INT6);
+      break;
+    case 7:
+      EIMSK &= ~(1 << INT7);
+      break;
 #elif defined(EICRA) && defined(EICRB) && defined(EIMSK)
     case 2:
       EIMSK &= ~(1 << INT0);
@@ -286,6 +344,17 @@ IMPLEMENT_ISR(INT1_vect, EXTERNAL_INT_1)
 IMPLEMENT_ISR(INT2_vect, EXTERNAL_INT_2)
 IMPLEMENT_ISR(INT3_vect, EXTERNAL_INT_3)
 IMPLEMENT_ISR(INT6_vect, EXTERNAL_INT_4)
+
+#elif defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega16U2__)
+
+IMPLEMENT_ISR(INT0_vect, EXTERNAL_INT_0)
+IMPLEMENT_ISR(INT1_vect, EXTERNAL_INT_1)
+IMPLEMENT_ISR(INT2_vect, EXTERNAL_INT_2)
+IMPLEMENT_ISR(INT3_vect, EXTERNAL_INT_3)
+IMPLEMENT_ISR(INT4_vect, EXTERNAL_INT_4)
+IMPLEMENT_ISR(INT5_vect, EXTERNAL_INT_5)
+IMPLEMENT_ISR(INT6_vect, EXTERNAL_INT_6)
+IMPLEMENT_ISR(INT7_vect, EXTERNAL_INT_7)
 
 #elif defined(EICRA) && defined(EICRB)
 


### PR DESCRIPTION
This commit actually places a copy of your existing code for interrupt handling, but doesn't do the "mix up" you have there for "historic reasons".

The "non-mixup" code is used for the ATmega32u2 and ATmega16u2.

I didn't check every possible interrupt as the board, I'm using, doesn't expose every pin, so please have a short look over the code.