### PR TITLE
Changed operator bool to explicit rather than implicit conversion in Serial

### DIFF
--- a/cores/arduino/Client.h
+++ b/cores/arduino/Client.h
@@ -37,7 +37,7 @@ public:
   virtual void flush() = 0;
   virtual void stop() = 0;
   virtual uint8_t connected() = 0;
-  virtual operator bool() = 0;
+  virtual explicit operator bool() = 0;
 protected:
   uint8_t* rawIPAddress(IPAddress& addr) { return addr.raw_address(); };
 };

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -132,7 +132,7 @@ class HardwareSerial : public Stream
     inline size_t write(unsigned int n) { return write((uint8_t)n); }
     inline size_t write(int n) { return write((uint8_t)n); }
     using Print::write; // pull in write(str) and write(buf, size) from Print
-    operator bool() { return true; }
+    explicit constexpr operator bool() { return true; }
 
     // Interrupt handlers - Not intended to be called externally
     inline void _rx_complete_irq(void);

--- a/cores/arduino/USBAPI.h
+++ b/cores/arduino/USBAPI.h
@@ -105,7 +105,7 @@ public:
 	virtual size_t write(uint8_t);
 	virtual size_t write(const uint8_t*, size_t);
 	using Print::write; // pull in write(str) and write(buf, size) from Print
-	operator bool();
+	explicit operator bool();
 
 	volatile uint8_t _rx_buffer_head;
 	volatile uint8_t _rx_buffer_tail;

--- a/libraries/SoftwareSerial/src/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.h
@@ -103,7 +103,7 @@ public:
   virtual int read();
   virtual int available();
   virtual void flush();
-  operator bool() { return true; }
+  explicit constexpr operator bool() { return true; }
   
   using Print::write;
 


### PR DESCRIPTION
If you were to notice that in every Serial based Class, we have a function with the type
`operator bool() { return true; }` 

By writing explicit, we can ensure that there is no form of implicit conversion or otherwise.
For further details view https://stackoverflow.com/questions/39995573/when-can-i-use-explicit-operator-bool-without-a-cast

This would ensure that `bool b = Serial1; `would not result in b getting a value

For example, comparing the following codes:-
```
struct T {
    operator bool() const { return true; }
};
int main()
{
    T t;
    bool B = t;
}
```
Does not result in an error due to an absence of explicit.
However, adding explicit we get an error that the conversion cannot be performed in the following sample.

```
struct T {
    explicit operator bool() const { return true; }
};
int main()
{
    T t;
    bool B = t; // error cannot convert t from bool
}
```

An Operator bool with explicit would render it compatible with [only these statements](https://stackoverflow.com/a/39995574)

For example
```
while(Serial);
if(Serial)
for(;Serial;)
```

**CONSTEXPR**

Further, I have marked these statements as `constexpr `given they indeed are constant compile time expressions and their values will not change dynamically at runtime