### PR TITLE
Enhance Serial class to control RS485 transmitter

### DIFF
--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -19,6 +19,7 @@
   Modified 28 September 2010 by Mark Sproul
   Modified 14 August 2012 by Alarus
   Modified 3 December 2013 by Matthijs Kooijman
+  Modified 02 February 2019 by Frank Sautter (RS485)
 */
 
 #ifndef HardwareSerial_h
@@ -101,6 +102,8 @@ class HardwareSerial : public Stream
     volatile uint8_t * const _udr;
     // Has any byte been written to the UART since begin()
     bool _written;
+    // pin number of RS485 transmit enable; 0xFF = not used
+    uint8_t _rs485TEpin = 0xFF;
 
     volatile rx_buffer_index_t _rx_buffer_head;
     volatile rx_buffer_index_t _rx_buffer_tail;
@@ -118,8 +121,9 @@ class HardwareSerial : public Stream
       volatile uint8_t *ubrrh, volatile uint8_t *ubrrl,
       volatile uint8_t *ucsra, volatile uint8_t *ucsrb,
       volatile uint8_t *ucsrc, volatile uint8_t *udr);
-    void begin(unsigned long baud) { begin(baud, SERIAL_8N1); }
-    void begin(unsigned long, uint8_t);
+    void begin(unsigned long baud) { begin(baud, SERIAL_8N1, 0xFF); };
+    void begin(unsigned long baud, uint8_t config) { begin(baud, config, 0xFF); };
+    void begin(unsigned long baud, uint8_t config, uint8_t rs485TEpin);
     void end();
     virtual int available(void);
     virtual int peek(void);
@@ -137,6 +141,7 @@ class HardwareSerial : public Stream
     // Interrupt handlers - Not intended to be called externally
     inline void _rx_complete_irq(void);
     void _tx_udr_empty_irq(void);
+    inline void _tx_complete_irq(void);
 };
 
 #if defined(UBRRH) || defined(UBRR0H)
@@ -158,4 +163,4 @@ class HardwareSerial : public Stream
 
 extern void serialEventRun(void) __attribute__((weak));
 
-#endif
+#endif  // HardwareSerial_h

--- a/cores/arduino/HardwareSerial0.cpp
+++ b/cores/arduino/HardwareSerial0.cpp
@@ -20,6 +20,7 @@
   Modified 28 September 2010 by Mark Sproul
   Modified 14 August 2012 by Alarus
   Modified 3 December 2013 by Matthijs Kooijman
+  Modified 02 February 2019 by Frank Sautter (RS485)
 */
 
 #include "Arduino.h"
@@ -62,6 +63,21 @@ ISR(USART_UDRE_vect)
 #endif
 {
   Serial._tx_udr_empty_irq();
+}
+
+#if defined(UART0_TX_vect)
+ISR(UART0_TX_vect)
+#elif defined(UART_TX_vect)
+ISR(UART_TX_vect)
+#elif defined(USART0_TX_vect)
+ISR(USART0_TX_vect)
+#elif defined(USART_TX_vect)
+ISR(USART_TX_vect)
+#else
+  #error "Don't know what the Transmit Complete vector is called for Serial0"
+#endif
+{
+  Serial._tx_complete_irq();
 }
 
 #if defined(UBRRH) && defined(UBRRL)

--- a/cores/arduino/HardwareSerial1.cpp
+++ b/cores/arduino/HardwareSerial1.cpp
@@ -20,6 +20,7 @@
   Modified 28 September 2010 by Mark Sproul
   Modified 14 August 2012 by Alarus
   Modified 3 December 2013 by Matthijs Kooijman
+  Modified 02 February 2019 by Frank Sautter (RS485)
 */
 
 #include "Arduino.h"
@@ -57,6 +58,18 @@ ISR(USART1_UDRE_vect)
 {
   Serial1._tx_udr_empty_irq();
 }
+
+#if defined(UART1_TX_vect)
+ISR(UART1_TX_vect)
+#elif defined(USART1_TX_vect)
+ISR(USART1_TX_vect)
+#else
+#error "Don't know what the Transmit Complete vector is called for Serial1"
+#endif
+{
+  Serial1._tx_complete_irq();
+}
+
 
 HardwareSerial Serial1(&UBRR1H, &UBRR1L, &UCSR1A, &UCSR1B, &UCSR1C, &UDR1);
 

--- a/cores/arduino/HardwareSerial2.cpp
+++ b/cores/arduino/HardwareSerial2.cpp
@@ -20,6 +20,7 @@
   Modified 28 September 2010 by Mark Sproul
   Modified 14 August 2012 by Alarus
   Modified 3 December 2013 by Matthijs Kooijman
+  Modified 02 February 2019 by Frank Sautter (RS485)
 */
 
 #include "Arduino.h"
@@ -44,6 +45,11 @@ ISR(USART2_RX_vect)
 ISR(USART2_UDRE_vect)
 {
   Serial2._tx_udr_empty_irq();
+}
+
+ISR(USART2_TX_vect)
+{
+  Serial2._tx_complete_irq();
 }
 
 HardwareSerial Serial2(&UBRR2H, &UBRR2L, &UCSR2A, &UCSR2B, &UCSR2C, &UDR2);

--- a/cores/arduino/HardwareSerial3.cpp
+++ b/cores/arduino/HardwareSerial3.cpp
@@ -20,6 +20,7 @@
   Modified 28 September 2010 by Mark Sproul
   Modified 14 August 2012 by Alarus
   Modified 3 December 2013 by Matthijs Kooijman
+  Modified 02 February 2019 by Frank Sautter (RS485)
 */
 
 #include "Arduino.h"
@@ -44,6 +45,11 @@ ISR(USART3_RX_vect)
 ISR(USART3_UDRE_vect)
 {
   Serial3._tx_udr_empty_irq();
+}
+
+ISR(USART3_TX_vect)
+{
+  Serial3._tx_complete_irq();
 }
 
 HardwareSerial Serial3(&UBRR3H, &UBRR3L, &UCSR3A, &UCSR3B, &UCSR3C, &UDR3);

--- a/cores/arduino/HardwareSerial_private.h
+++ b/cores/arduino/HardwareSerial_private.h
@@ -19,11 +19,12 @@
   Modified 23 November 2006 by David A. Mellis
   Modified 28 September 2010 by Mark Sproul
   Modified 14 August 2012 by Alarus
+	Modified 02 February 2019 by Frank Sautter (RS485)
 */
 
 #include "wiring_private.h"
 
-// this next line disables the entire HardwareSerial.cpp, 
+// this next line disables the entire HardwareSerial.cpp,
 // this is so I can support Attiny series and any other chip without a uart
 #if defined(HAVE_HWSERIAL0) || defined(HAVE_HWSERIAL1) || defined(HAVE_HWSERIAL2) || defined(HAVE_HWSERIAL3)
 
@@ -118,6 +119,16 @@ void HardwareSerial::_rx_complete_irq(void)
     // Parity error, read byte but discard it
     *_udr;
   };
+}
+
+
+void HardwareSerial::_tx_complete_irq(void)
+{
+  // interrupt on end of serial transmission when the last stop bit was sent
+  if (_rs485TEpin != 0xFF) {
+    // disable RS485 transmitter if pin defined
+    digitalWrite(_rs485TEpin, LOW);
+  }
 }
 
 #endif // whole file


### PR DESCRIPTION
This pull request allows automatic control of the transmit enable signal `TE` on half-duplex RS485 transceivers when a character has to be sent and disables the TE pin when the last stop bit was sent `TXC`, by utilizing the USART transmit complete interrupt `USART_TXC_vect`.

For comparison please refer to the independent library [RS485HwSerial](https://github.com/sauttefk/RS485HwSerial).
```
// RS485 transceiver enable pin as 3rd parameter
RS485HwSerial1.begin(RS485_BPS, SERIAL_8N1, RS485_TE_PIN);
```