### PR TITLE
Remove unnecessary delay in Serial_ operator bool in CDC.cpp

### DIFF
--- a/cores/arduino/CDC.cpp
+++ b/cores/arduino/CDC.cpp
@@ -250,11 +250,11 @@ size_t Serial_::write(const uint8_t *buffer, size_t size)
 // We add a short delay before returning to fix a bug observed by Federico
 // where the port is configured (lineState != 0) but not quite opened.
 Serial_::operator bool() {
-	bool result = false;
-	if (_usbLineInfo.lineState > 0) 
-		result = true;
-	delay(10);
-	return result;
+	if (_usbLineInfo.lineState > 0) {
+		delay(10);
+		return true;
+	}
+	return false;
 }
 
 unsigned long Serial_::baud() {


### PR DESCRIPTION
The operator bool was implemented previously [as follows in CDC.cpp](https://github.com/arduino/ArduinoCore-avr/blob/5755ddea49fa69d6c505c772ebee5af5078e2ebf/cores/arduino/CDC.cpp#L252)
```
Serial_::operator bool() {
	bool result = false;
	if (_usbLineInfo.lineState > 0) 
		result = true;
	delay(10);
	return result;
}
```
It had the [following comments there](https://github.com/arduino/ArduinoCore-avr/blob/5755ddea49fa69d6c505c772ebee5af5078e2ebf/cores/arduino/CDC.cpp#L250)
_We add a short delay before returning to fix a bug observed by Federico
where the port is configured (lineState != 0) but not quite opened._

As you can observe here, the delay is only required in case lineState != 0( or lineState > 0 [as lineState is unsigned](https://github.com/arduino/ArduinoCore-avr/blob/5755ddea49fa69d6c505c772ebee5af5078e2ebf/cores/arduino/CDC.cpp#L31))
However, currently for unknown reasons, a delay of 10 ms is added even if lineState == 0
As such my correction which I post below simply consists of delaying only when lineState > 0
```
Serial_::operator bool() {
   if (_usbLineInfo.lineState > 0) {
      delay(10);
      return true;
   }
   return false;
}
```

If there is any logic to the delay even when lineState == 0, then we should update the comments.