### PR TITLE
Fix for issue #25 potential corruption in attachInterrupt.

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -147,8 +147,9 @@ unsigned long pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout);
 void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val);
 uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder);
 
-void attachInterrupt(uint8_t, void (*)(void), int mode);
-void detachInterrupt(uint8_t);
+// The pin number has to be signed as NOT_AN_INTERRUPT is signed. (NDunbar)
+void attachInterrupt(int8_t, void (*)(void), int mode);
+void detachInterrupt(int8_t);
 
 void setup(void);
 void loop(void);

--- a/cores/arduino/WInterrupts.c
+++ b/cores/arduino/WInterrupts.c
@@ -66,8 +66,8 @@ static volatile voidFuncPtr intFunc[EXTERNAL_NUM_INTERRUPTS] = {
 #endif
 };
 
-void attachInterrupt(uint8_t interruptNum, void (*userFunc)(void), int mode) {
-  if(interruptNum < EXTERNAL_NUM_INTERRUPTS) {
+void attachInterrupt(int8_t interruptNum, void (*userFunc)(void), int mode) {
+  if((interruptNum < EXTERNAL_NUM_INTERRUPTS) && (interruptNum != NOT_AN_INTERRUPT)) {
     intFunc[interruptNum] = userFunc;
     
     // Configure the interrupt mode (trigger on low input, any change, rising
@@ -183,8 +183,8 @@ void attachInterrupt(uint8_t interruptNum, void (*userFunc)(void), int mode) {
   }
 }
 
-void detachInterrupt(uint8_t interruptNum) {
-  if(interruptNum < EXTERNAL_NUM_INTERRUPTS) {
+void detachInterrupt(int8_t interruptNum) {
+  if((interruptNum < EXTERNAL_NUM_INTERRUPTS) && (interruptNum != NOT_AN_INTERRUPT)) {
     // Disable the interrupt.  (We can't assume that interruptNum is equal
     // to the number of the EIMSK bit to clear, as this isn't true on the 
     // ATmega8.  There, INT0 is 6 and INT1 is 7.)


### PR DESCRIPTION
I've updated this fix to make `attachInterrupt()` and `detachInterrupt()` take a signed interrupt number as `NOT_AN_INTERRUPT` is itself signed. In addition the code now checks for `NOT_AN_INTERRUPT` being passed, and take no action if so. 