### PR TITLE
Fix error: this statement may fall through (twi.c)

### DIFF
--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -35,6 +35,12 @@
 #define sbi(sfr, bit) (_SFR_BYTE(sfr) |= _BV(bit))
 #endif
 
+#if defined(__GNUC__) && __GNUC__ >= 7
+#define FALL_THROUGH __attribute__((fallthrough))
+#else
+#define FALL_THROUGH
+#endif /* __GNUC__ >= 7 */
+
 #include "pins_arduino.h"
 #include "twi.h"
 
@@ -445,6 +451,7 @@ ISR(TWI_vect)
     case TW_MR_DATA_ACK: // data received, ack sent
       // put byte into buffer
       twi_masterBuffer[twi_masterBufferIndex++] = TWDR;
+      FALL_THROUGH; /*@fallthrough@*/
     case TW_MR_SLA_ACK:  // address sent, ack received
       // ack if more bytes are expected, otherwise nack
       if(twi_masterBufferIndex < twi_masterBufferLength){
@@ -530,6 +537,7 @@ ISR(TWI_vect)
         twi_txBufferLength = 1;
         twi_txBuffer[0] = 0x00;
       }
+      FALL_THROUGH; /*@fallthrough@*/
       // transmit first byte from buffer, fall
     case TW_ST_DATA_ACK: // byte sent, ack returned
       // copy data to output register


### PR DESCRIPTION
Fixes the following error while compiling using gcc v8.2.0
with either -Wextra or -Wimplicit-fallthrough=(>=1):

libraries/ArduinoCore-avr/libraries/Wire/src/utility/twi.c: In function '__vector_24':
libraries/ArduinoCore-avr/libraries/Wire/src/utility/twi.c:447:49: error: this statement may fall through [-Werror=implicit-fallthrough=]
       twi_masterBuffer[twi_masterBufferIndex++] = TWDR;
                                                 ^
libraries/ArduinoCore-avr/libraries/Wire/src/utility/twi.c:448:5: note: here
     case TW_MR_SLA_ACK:  // address sent, ack received
     ^~~~
libraries/ArduinoCore-avr/libraries/Wire/src/utility/twi.c:529:9: error: this statement may fall through [-Werror=implicit-fallthrough=]
       if(0 == twi_txBufferLength){
         ^
libraries/ArduinoCore-avr/libraries/Wire/src/utility/twi.c:534:5: note: here
     case TW_ST_DATA_ACK: // byte sent, ack returned
     ^~~~

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>