### PR TITLE
Fix unused variable warning for non-pluggable USB in SendDescriptor

### DIFF
--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -496,14 +496,13 @@ bool SendConfiguration(int maxlen)
 static
 bool SendDescriptor(USBSetup& setup)
 {
-	int ret;
 	u8 t = setup.wValueH;
 	if (USB_CONFIGURATION_DESCRIPTOR_TYPE == t)
 		return SendConfiguration(setup.wLength);
 
 	InitControl(setup.wLength);
 #ifdef PLUGGABLE_USB_ENABLED
-	ret = PluggableUSB().getDescriptor(setup);
+	int ret = PluggableUSB().getDescriptor(setup);
 	if (ret != 0) {
 		return (ret > 0 ? true : false);
 	}


### PR DESCRIPTION
Avoids the unused variable warning if USB is enabled but pluggable USB is not.