### PR TITLE
Single pin SoftwareSerial setup

### DIFF
--- a/libraries/SoftwareSerial/examples/OnePinMidiTX/OnePinMidiTX.ino
+++ b/libraries/SoftwareSerial/examples/OnePinMidiTX/OnePinMidiTX.ino
@@ -1,5 +1,5 @@
 /*
- Send MIDI notes via Software serial.
+ Send MIDI notes via software serial.
 
  Demonstrates using only one pin (TX), if bidirectional communication isn't needed.
 

--- a/libraries/SoftwareSerial/examples/OnePinMidiTX/OnePinMidiTX.ino
+++ b/libraries/SoftwareSerial/examples/OnePinMidiTX/OnePinMidiTX.ino
@@ -1,0 +1,35 @@
+/*
+ Send MIDI notes via Software serial.
+
+ Demonstrates using only one pin (TX), if bidirectional communication isn't needed.
+
+ Based on https://www.arduino.cc/en/tutorial/midi and https://github.com/arduino/ArduinoCore-avr/blob/5755ddea49fa69d6c505c772ebee5af5078e2ebf/libraries/SoftwareSerial/examples/SoftwareSerialExample/SoftwareSerialExample.ino
+
+ This example code is in the public domain.
+
+ */
+#include <SoftwareSerial.h>
+
+#define MIDI_OUT_TX_PIN 9
+
+SoftwareSerial midiOutSerial = SoftwareSerial();
+
+void setup() {
+  midiOutSerial.setTX(MIDI_OUT_TX_PIN);
+  // set the MIDI data rate for the SoftwareSerial port
+  midiOutSerial.begin(31250);
+}
+
+// Sends a Bb 3 MIDI every other second.
+void loop() {
+  noteOn(0x90, 0x3A, 0x45);
+  delay(1000);
+  noteOn(0x90, 0x3A, 0x00);
+  delay(1000);
+}
+
+void noteOn(int cmd, int pitch, int velocity) {
+  midiOutSerial.write(cmd);
+  midiOutSerial.write(pitch);
+  midiOutSerial.write(velocity);
+}

--- a/libraries/SoftwareSerial/examples/OnePinMidiTX/OnePinMidiTX.ino
+++ b/libraries/SoftwareSerial/examples/OnePinMidiTX/OnePinMidiTX.ino
@@ -3,7 +3,7 @@
 
  Demonstrates using only one pin (TX), if bidirectional communication isn't needed.
 
- Based on https://www.arduino.cc/en/tutorial/midi and https://github.com/arduino/ArduinoCore-avr/blob/5755ddea49fa69d6c505c772ebee5af5078e2ebf/libraries/SoftwareSerial/examples/SoftwareSerialExample/SoftwareSerialExample.ino
+ Based on https://www.arduino.cc/en/tutorial/midi and https://www.arduino.cc/en/Tutorial/SoftwareSerialExample
 
  This example code is in the public domain.
 

--- a/libraries/SoftwareSerial/examples/OnePinMidiTX/OnePinMidiTX.ino
+++ b/libraries/SoftwareSerial/examples/OnePinMidiTX/OnePinMidiTX.ino
@@ -16,11 +16,14 @@ SoftwareSerial midiOutSerial = SoftwareSerial();
 
 void setup() {
   midiOutSerial.setTX(MIDI_OUT_TX_PIN);
-  // set the MIDI data rate for the SoftwareSerial port
+  // Set the MIDI data rate for the SoftwareSerial port.
   midiOutSerial.begin(31250);
 }
 
-// Sends a Bb 3 MIDI every other second.
+// 0x90: note on
+// 0x3A: Bb 3 note
+// 0x45: medium velocity
+// 0x00: zero velocity (silence)
 void loop() {
   noteOn(0x90, 0x3A, 0x45);
   delay(1000);

--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -1,11 +1,11 @@
 /*
-SoftwareSerial.cpp (formerly NewSoftSerial.cpp) - 
+SoftwareSerial.cpp (formerly NewSoftSerial.cpp) -
 Multi-instance software serial library for Arduino/Wiring
 -- Interrupt-driven receive and other improvements by ladyada
    (http://ladyada.net)
 -- Tuning, circular buffer, derivation from class Print/Stream,
    multi-instance support, porting to 8MHz processors,
-   various optimizations, PROGMEM delay tables, inverse logic and 
+   various optimizations, PROGMEM delay tables, inverse logic and
    direct port writing by Mikal Hart (http://www.arduiniana.org)
 -- Pin change interrupt macros by Paul Stoffregen (http://www.pjrc.com)
 -- 20MHz processor support by Garrett Mace (http://www.macetech.com)
@@ -35,9 +35,9 @@ http://arduiniana.org.
 #define _DEBUG 0
 #define _DEBUG_PIN1 11
 #define _DEBUG_PIN2 13
-// 
+//
 // Includes
-// 
+//
 #include <avr/interrupt.h>
 #include <avr/pgmspace.h>
 #include <Arduino.h>
@@ -48,7 +48,7 @@ http://arduiniana.org.
 // Statics
 //
 SoftwareSerial *SoftwareSerial::active_object = 0;
-uint8_t SoftwareSerial::_receive_buffer[_SS_MAX_RX_BUFF]; 
+uint8_t SoftwareSerial::_receive_buffer[_SS_MAX_RX_BUFF];
 volatile uint8_t SoftwareSerial::_receive_buffer_tail = 0;
 volatile uint8_t SoftwareSerial::_receive_buffer_head = 0;
 
@@ -77,13 +77,13 @@ inline void DebugPulse(uint8_t, uint8_t) {}
 // Private methods
 //
 
-/* static */ 
-inline void SoftwareSerial::tunedDelay(uint16_t delay) { 
+/* static */
+inline void SoftwareSerial::tunedDelay(uint16_t delay) {
   _delay_loop_2(delay);
 }
 
 // This function sets the current object as the "listening"
-// one and returns true if it replaces another 
+// one and returns true if it replaces another
 bool SoftwareSerial::listen()
 {
   if (!_rx_delay_stopbit)
@@ -137,7 +137,7 @@ void SoftwareSerial::recv()
     "push r26 \n\t"
     "push r27 \n\t"
     ::);
-#endif  
+#endif
 
   uint8_t d = 0;
 
@@ -174,8 +174,8 @@ void SoftwareSerial::recv()
       // save new data in buffer: tail points to where byte goes
       _receive_buffer[_receive_buffer_tail] = d; // save new byte
       _receive_buffer_tail = next;
-    } 
-    else 
+    }
+    else
     {
       DebugPulse(_DEBUG_PIN1, 1);
       _buffer_overflow = true;
@@ -244,19 +244,22 @@ ISR(PCINT3_vect, ISR_ALIASOF(PCINT0_vect));
 #endif
 
 //
-// Constructor
+// Constructors
 //
-SoftwareSerial::SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverse_logic /* = false */) : 
-  _rx_delay_centering(0),
-  _rx_delay_intrabit(0),
-  _rx_delay_stopbit(0),
-  _tx_delay(0),
+SoftwareSerial::SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverse_logic /* = false */) :
   _buffer_overflow(false),
   _inverse_logic(inverse_logic)
 {
   setTX(transmitPin);
   setRX(receivePin);
 }
+
+// Use this constructor if only RX or TX communication is required and
+// set the pin by calling SoftwareSerial::setRX or SoftwareSerial::setTX.
+SoftwareSerial::SoftwareSerial(bool inverse_logic /* = false */) :
+  _buffer_overflow(false),
+  _inverse_logic(inverse_logic)
+{}
 
 //
 // Destructor
@@ -272,6 +275,7 @@ void SoftwareSerial::setTX(uint8_t tx)
   // the pin would be output low for a short while before switching to
   // output high. Now, it is input with pullup for a short while, which
   // is fine. With inverse logic, either order is fine.
+  _tx_delay = 0;
   digitalWrite(tx, _inverse_logic ? LOW : HIGH);
   pinMode(tx, OUTPUT);
   _transmitBitMask = digitalPinToBitMask(tx);
@@ -281,6 +285,9 @@ void SoftwareSerial::setTX(uint8_t tx)
 
 void SoftwareSerial::setRX(uint8_t rx)
 {
+  _rx_delay_centering = 0;
+  _rx_delay_intrabit = 0;
+  _rx_delay_stopbit = 0;
   pinMode(rx, INPUT);
   if (!_inverse_logic)
     digitalWrite(rx, HIGH);  // pullup for normal logic!
@@ -463,7 +470,7 @@ size_t SoftwareSerial::write(uint8_t b)
 
   SREG = oldSREG; // turn interrupts back on
   tunedDelay(_tx_delay);
-  
+
   return 1;
 }
 

--- a/libraries/SoftwareSerial/src/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.h
@@ -1,11 +1,11 @@
 /*
-SoftwareSerial.h (formerly NewSoftSerial.h) - 
+SoftwareSerial.h (formerly NewSoftSerial.h) -
 Multi-instance software serial library for Arduino/Wiring
 -- Interrupt-driven receive and other improvements by ladyada
    (http://ladyada.net)
 -- Tuning, circular buffer, derivation from class Print/Stream,
    multi-instance support, porting to 8MHz processors,
-   various optimizations, PROGMEM delay tables, inverse logic and 
+   various optimizations, PROGMEM delay tables, inverse logic and
    direct port writing by Mikal Hart (http://www.arduiniana.org)
 -- Pin change interrupt macros by Paul Stoffregen (http://www.pjrc.com)
 -- 20MHz processor support by Garrett Mace (http://www.macetech.com)
@@ -69,7 +69,7 @@ private:
   uint16_t _inverse_logic:1;
 
   // static data
-  static uint8_t _receive_buffer[_SS_MAX_RX_BUFF]; 
+  static uint8_t _receive_buffer[_SS_MAX_RX_BUFF];
   static volatile uint8_t _receive_buffer_tail;
   static volatile uint8_t _receive_buffer_head;
   static SoftwareSerial *active_object;
@@ -77,8 +77,6 @@ private:
   // private methods
   inline void recv() __attribute__((__always_inline__));
   uint8_t rx_pin_read();
-  void setTX(uint8_t transmitPin);
-  void setRX(uint8_t receivePin);
   inline void setRxIntMsk(bool enable) __attribute__((__always_inline__));
 
   // Return num - sub, or 1 if the result would be < 1
@@ -90,6 +88,7 @@ private:
 public:
   // public methods
   SoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverse_logic = false);
+  SoftwareSerial(bool inverse_logic = false);
   ~SoftwareSerial();
   void begin(long speed);
   bool listen();
@@ -98,13 +97,15 @@ public:
   bool stopListening();
   bool overflow() { bool ret = _buffer_overflow; if (ret) _buffer_overflow = false; return ret; }
   int peek();
+  void setTX(uint8_t transmitPin);
+  void setRX(uint8_t receivePin);
 
   virtual size_t write(uint8_t byte);
   virtual int read();
   virtual int available();
   virtual void flush();
   operator bool() { return true; }
-  
+
   using Print::write;
 
   // public only for easy access by interrupt handlers

--- a/platform.txt
+++ b/platform.txt
@@ -6,7 +6,7 @@
 # https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5-3rd-party-Hardware-specification
 
 name=Arduino AVR Boards
-version=1.6.22
+version=1.6.23
 
 # AVR compile variables
 # ---------------------


### PR DESCRIPTION
Allow SoftwareSerial to use only one pin (RX or TX) instead of two when a project only needs one way SoftwareSerial communication.
