### PR TITLE
Minor optimization in shiftOut function

### DIFF
--- a/cores/arduino/wiring_shift.c
+++ b/cores/arduino/wiring_shift.c
@@ -46,7 +46,7 @@ void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val)
 			digitalWrite(dataPin, val & 1);
 			val >>= 1;
 		} else {	
-			digitalWrite(dataPin, val & 128);
+			digitalWrite(dataPin, (val & 128) != 0);
 			val <<= 1;
 		}
 			

--- a/cores/arduino/wiring_shift.c
+++ b/cores/arduino/wiring_shift.c
@@ -42,10 +42,13 @@ void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val)
 	uint8_t i;
 
 	for (i = 0; i < 8; i++)  {
-		if (bitOrder == LSBFIRST)
-			digitalWrite(dataPin, !!(val & (1 << i)));
-		else	
-			digitalWrite(dataPin, !!(val & (1 << (7 - i))));
+		if (bitOrder == LSBFIRST) {
+			digitalWrite(dataPin, val & 1);
+			val >>= 1;
+		} else {	
+			digitalWrite(dataPin, val & 128);
+			val <<= 1;
+		}
 			
 		digitalWrite(clockPin, HIGH);
 		digitalWrite(clockPin, LOW);		


### PR DESCRIPTION
Hi!
I found this -very-little optimization in a function I was using with a 595 shift registers' project: while I was trying to understand what this function used to do, I figured out a (IMHO) cleaner solution.

Compiling an example with `gcc -S` generated a file 10-15 instruction lines shorter than the previous version, which could lead (i think) to a smaller workload for such a simple operation.

I didn't quite understand the double exclamation marks before the shift operation `!!(val & ...` so I don't know if this breaks something. Let me know!
Keep up with Arduino 'cause it's awesome!