### PR TITLE
Added listen() and isListening() to Stream to make it more general

### DIFF
--- a/cores/arduino/Stream.h
+++ b/cores/arduino/Stream.h
@@ -107,6 +107,12 @@ class Stream : public Print
   String readString();
   String readStringUntil(char terminator);
 
+
+  // for compatibility with derived classes
+  virtual bool listen(){return true;}
+  virtual bool isListening(){return true;}
+  
+
   protected:
   long parseInt(char ignore) { return parseInt(SKIP_ALL, ignore); }
   float parseFloat(char ignore) { return parseFloat(SKIP_ALL, ignore); }


### PR DESCRIPTION
If we want to create a class that uses a general Stream* in order to have some data flow capabilities (input/output for chars), we cannot use a HardwareSerial or a SoftwareSerial reference on the same way, since their parent (Stream) have no listen() nor isListenning() methods.

```C++ 
  virtual bool listen(){return true;}
  virtual bool isListening(){return true;}
```

By adding that methods within the Stream class, it should be more general, and would not affect other classes that inherits from it.