### PR TITLE
Implemented Multiple TwoWire Slave address support

### DIFF
--- a/libraries/Wire/examples/slave_multi_receiver/slave_receiver.ino
+++ b/libraries/Wire/examples/slave_multi_receiver/slave_receiver.ino
@@ -1,0 +1,40 @@
+// Wire Multi-Address Slave Receiver
+// by Tijs van Roon
+
+// Demonstrates use of the Wire library with multiple slave addresses
+// Receives data as an I2C/TWI slave device
+// Refer to the "Wire Master Writer" example for use with this
+
+// Created 26 May 2019
+
+// This example code is in the public domain.
+
+#include <Wire.h>
+
+void setup() {
+  uint8_t addr1 = 0x08, addr2 = 0x10; // our slave addresses
+  uint8_t addr_mask = (addr1 | addr2) ^ (addr1 & addr2);
+
+  Wire.begin((uint8_t)(addr1 | addr2), addr_mask); // join i2c bus with both addresses
+  Wire.onReceive(receiveEvent); // register event
+  Serial.begin(9600);           // start serial for output
+}
+
+void loop() {
+  delay(100);
+}
+
+// function that executes whenever data is received from master
+// this function is registered as an event, see setup()
+void receiveEvent(int howMany) {
+  int address = Wire.getLastAddress();
+  Serial.print("0x"); 
+  Serial.print(address, HEX); 
+  Serial.print(": ");
+  while (1 < Wire.available()) { // loop through all but the last
+    char c = Wire.read(); // receive byte as a character
+    Serial.print(c);         // print the character
+  }
+  int x = Wire.read();    // receive byte as an integer
+  Serial.println(x);         // print the integer
+}

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -34,6 +34,7 @@ extern "C" {
 uint8_t TwoWire::rxBuffer[BUFFER_LENGTH];
 uint8_t TwoWire::rxBufferIndex = 0;
 uint8_t TwoWire::rxBufferLength = 0;
+uint8_t TwoWire::rxAddress = 0;
 
 uint8_t TwoWire::txAddress = 0;
 uint8_t TwoWire::txBuffer[BUFFER_LENGTH];
@@ -273,8 +274,13 @@ void TwoWire::flush(void)
   // XXX: to be implemented.
 }
 
+uint8_t TwoWire::getLastAddress()
+{
+  return rxAddress; 
+};
+
 // behind the scenes function that is called when data is received
-void TwoWire::onReceiveService(uint8_t* inBytes, int numBytes)
+void TwoWire::onReceiveService(uint8_t addr, uint8_t* inBytes, int numBytes)
 {
   // don't bother if user hasn't registered a callback
   if(!user_onReceive){
@@ -294,6 +300,7 @@ void TwoWire::onReceiveService(uint8_t* inBytes, int numBytes)
   // set rx iterator vars
   rxBufferIndex = 0;
   rxBufferLength = numBytes;
+  rxAddress = addr;
   // alert user program
   user_onReceive(numBytes);
 }

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -65,15 +65,15 @@ void TwoWire::begin(void)
   twi_attachSlaveRxEvent(onReceiveService); // default callback must exist
 }
 
-void TwoWire::begin(uint8_t address)
+void TwoWire::begin(uint8_t address, uint8_t mask)
 {
   begin();
-  twi_setAddress(address);
+  twi_setAddress(address, mask);
 }
 
-void TwoWire::begin(int address)
+void TwoWire::begin(int address, int mask)
 {
-  begin((uint8_t)address);
+  begin((uint8_t)address, (uint8_t)mask);
 }
 
 void TwoWire::end(void)

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -36,6 +36,7 @@ class TwoWire : public Stream
     static uint8_t rxBuffer[];
     static uint8_t rxBufferIndex;
     static uint8_t rxBufferLength;
+    static uint8_t rxAddress;
 
     static uint8_t txAddress;
     static uint8_t txBuffer[];
@@ -46,7 +47,7 @@ class TwoWire : public Stream
     static void (*user_onRequest)(void);
     static void (*user_onReceive)(int);
     static void onRequestService(void);
-    static void onReceiveService(uint8_t*, int);
+    static void onReceiveService(uint8_t, uint8_t*, int);
   public:
     TwoWire();
     void begin();
@@ -69,6 +70,7 @@ class TwoWire : public Stream
     virtual int read(void);
     virtual int peek(void);
     virtual void flush(void);
+    uint8_t getLastAddress();
     void onReceive( void (*)(int) );
     void onRequest( void (*)(void) );
 

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -50,8 +50,8 @@ class TwoWire : public Stream
   public:
     TwoWire();
     void begin();
-    void begin(uint8_t);
-    void begin(int);
+    void begin(uint8_t addr, uint8_t mask = 0xFF);
+    void begin(int, int);
     void end();
     void setClock(uint32_t);
     void beginTransmission(uint8_t);

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -112,10 +112,11 @@ void twi_disable(void)
  * Input    none
  * Output   none
  */
-void twi_setAddress(uint8_t address)
+void twi_setAddress(uint8_t address, uint8_t mask)
 {
   // set twi slave address (skip over TWGCE bit)
   TWAR = address << 1;
+  TWAMR = mask << 1;
 }
 
 /* 

--- a/libraries/Wire/src/utility/twi.h
+++ b/libraries/Wire/src/utility/twi.h
@@ -40,7 +40,7 @@
   
   void twi_init(void);
   void twi_disable(void);
-  void twi_setAddress(uint8_t);
+  void twi_setAddress(uint8_t, uint8_t);
   void twi_setFrequency(uint32_t);
   uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t);
   uint8_t twi_writeTo(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t);

--- a/libraries/Wire/src/utility/twi.h
+++ b/libraries/Wire/src/utility/twi.h
@@ -45,7 +45,7 @@
   uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t);
   uint8_t twi_writeTo(uint8_t, uint8_t*, uint8_t, uint8_t, uint8_t);
   uint8_t twi_transmit(const uint8_t*, uint8_t);
-  void twi_attachSlaveRxEvent( void (*)(uint8_t*, int) );
+  void twi_attachSlaveRxEvent( void (*)(uint8_t, uint8_t*, int) );
   void twi_attachSlaveTxEvent( void (*)(void) );
   void twi_reply(uint8_t);
   void twi_stop(void);


### PR DESCRIPTION
I require my device to listen to multiple slave addresses. This can be 'hacked' by directly writing the mask to the TWAMR register. But because the TwoWire library does not store the contents of the TWDR when it enters slave-receive mode I was unable to retrieve the actual address that was written to in the onReceive() handler.

I was able to incorporate both into libraries/Wire with an example and made a pull request.
I've made two changes:
 1. support for slave-address mask setting
     begin() allows for an (optional) mask parameter, which is defaulted to 0xFF.
 2. retrieving the slave address written to from Wire
     I've stored the value of TWDR when the receiver goes into TWI_SRX mode. This value can then be 
     retreived with the Wire.getLastAddress() method.

I would prefer having this address passed as param in the onReceive callback or another option (as user:tinoest mentions on the [forum](https://forum.arduino.cc/index.php?topic=168463.0)) would be to write the slave address to the rxBuffer first. But both break backwards compatibility as it would break existing sketches.
