### PR TITLE
Cast pins to signed integers to avoid Wtype-limits compile warning

### DIFF
--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -121,7 +121,7 @@ String::String(double value, unsigned char decimalPlaces)
 
 String::~String()
 {
-	free(buffer);
+	if (buffer) free(buffer);
 }
 
 /*********************************************/

--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -316,7 +316,7 @@ void SoftwareSerial::begin(long speed)
   _tx_delay = subtract_cap(bit_delay, 15 / 4);
 
   // Only setup rx when we have a valid PCINT for this pin
-  if (digitalPinToPCICR(_receivePin)) {
+  if (digitalPinToPCICR((int8_t)_receivePin)) {
     #if GCC_VERSION > 40800
     // Timings counted from gcc 4.8.2 output. This works up to 115200 on
     // 16Mhz and 57600 on 8Mhz.
@@ -357,7 +357,7 @@ void SoftwareSerial::begin(long speed)
     // Enable the PCINT for the entire port here, but never disable it
     // (others might also need it, so we disable the interrupt by using
     // the per-pin PCMSK register).
-    *digitalPinToPCICR(_receivePin) |= _BV(digitalPinToPCICRbit(_receivePin));
+    *digitalPinToPCICR((int8_t)_receivePin) |= _BV(digitalPinToPCICRbit(_receivePin));
     // Precalculate the pcint mask register and value, so setRxIntMask
     // can be used inside the ISR without costing too much time.
     _pcint_maskreg = digitalPinToPCMSK(_receivePin);


### PR DESCRIPTION
Using the current stock `SoftwareSerial` with all warnings enabled results in messages such as the following, observed in a Travis CI build:

```
In file included from /home/travis/.arduino15/packages/arduino/hardware/avr/1.6.23/cores/arduino/Arduino.h:257:0,
                 from /home/travis/.arduino15/packages/arduino/hardware/avr/1.6.23/libraries/SoftwareSerial/src/SoftwareSerial.cpp:43:
/home/travis/.arduino15/packages/arduino/hardware/avr/1.6.23/libraries/SoftwareSerial/src/SoftwareSerial.cpp: In member function 'void SoftwareSerial::begin(long int)':
/home/travis/.arduino15/packages/arduino/hardware/avr/1.6.23/variants/standard/pins_arduino.h:74:39: warning: comparison is always true due to limited range of data type [-Wtype-limits]
 #define digitalPinToPCICR(p)    (((p) >= 0 && (p) <= 21) ? (&PCICR) : ((uint8_t *)0))
                                       ^
/home/travis/.arduino15/packages/arduino/hardware/avr/1.6.23/libraries/SoftwareSerial/src/SoftwareSerial.cpp:319:7: note: in expansion of macro 'digitalPinToPCICR'
   if (digitalPinToPCICR(_receivePin)) {
       ^
/home/travis/.arduino15/packages/arduino/hardware/avr/1.6.23/variants/standard/pins_arduino.h:74:39: warning: comparison is always true due to limited range of data type [-Wtype-limits]
 #define digitalPinToPCICR(p)    (((p) >= 0 && (p) <= 21) ? (&PCICR) : ((uint8_t *)0))
                                       ^
/home/travis/.arduino15/packages/arduino/hardware/avr/1.6.23/libraries/SoftwareSerial/src/SoftwareSerial.cpp:360:6: note: in expansion of macro 'digitalPinToPCICR'
     *digitalPinToPCICR(_receivePin) |= _BV(digitalPinToPCICRbit(_receivePin));
      ^
```

This is due to the fact that `SoftwareSerial` uses the `digitalPinToPCICR` macro with an argument that is an unsigned data type, specifically `uint8_t`. The `>= 0` comparison logically always evaluates to true, generating the warning shown here.

To solve this, because I hate compiler warnings being generated for no good reason, I've modified the AVR core `SoftwareSerial.cpp` file to explicitly cast the two offending arguments to `int8_t` instead. This eliminates the warnings.