### PR TITLE
Make String::concat(char) put the char directly

### DIFF
--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -279,10 +279,11 @@ unsigned char String::concat(const char *cstr)
 
 unsigned char String::concat(char c)
 {
-	char buf[2];
-	buf[0] = c;
-	buf[1] = 0;
-	return concat(buf, 1);
+	unsigned int newlen = len + 1;
+	if (!reserve(newlen)) return 0;
+	buffer[len] = c;
+	len = newlen;
+	return 1;
 }
 
 unsigned char String::concat(unsigned char num)

--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -282,6 +282,7 @@ unsigned char String::concat(char c)
 	unsigned int newlen = len + 1;
 	if (!reserve(newlen)) return 0;
 	buffer[len] = c;
+	buffer[newlen] = '\0';
 	len = newlen;
 	return 1;
 }


### PR DESCRIPTION
This pull request makes a performance enhancement to `String::concat(char)`.
The original `String::concat(char)` declares a `char buf[2]` to make a null-terminated string and calls `String::concat(const char *cstr, unsigned int length)`, and then `String::concat(const char *cstr, unsigned int length)` is going to check the parameter cstr not null and length not 0, it unnecessary and not optimized by compiler.
The `String::concat(char)` now only check `reserve()` and put the char into buffer directly.

I test this code on Arduino Mega 2560 and with compile option `-O2`, `-O3` and defualt `-Os`

    void setup()
    {
        const size_t test_size = 256;
        const size_t write_size = test_size - 1;
        String str;
        str.reserve(write_size);
        uint32_t time_start = micros();
        for (size_t i = 0; i < write_size; i++)
        {
            str.concat('0');
        }
        uint32_t time_end = micros();
        Serial.print(time_end - time_start);
        Serial.println(" us");
    }

    void loop() {}

And the result

| Code | Optimize | DATA | PROGRAM | result | 
|:--:|:--:|:--:|:--:|:--:| 
| Original | -Os | 202 | 3434 | 1732 |
| New | -Os | 202 | 3422 | 1252 |
| Original | -O2 | 202 | 3428 | 1700 |
| New | -O2 | 202 | 3428 | 1220 |
| Original | -O3 | 202 | 4826 | 1044 |
| New | -O3 | 202 | 4800 | 576 |

It shows the code size smaller and performance enhanced.