### PR TITLE
Correct yunmini.bootloader.file on boards.txt

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -946,7 +946,7 @@ yunmini.bootloader.tool=avrdude
 yunmini.bootloader.low_fuses=0xff
 yunmini.bootloader.high_fuses=0xd8
 yunmini.bootloader.extended_fuses=0xfb
-yunmini.bootloader.file=caterina/Caterina-Yunmini.hex
+yunmini.bootloader.file=caterina/Caterina-YunMini.hex
 yunmini.bootloader.unlock_bits=0x3F
 yunmini.bootloader.lock_bits=0x2F
 


### PR DESCRIPTION
It is a minor issue but it might cause a problem under the case-sensitive system.
(It seems to be no problem on Windows but not on Linux)

I don't know about the naming convention on the bootloader files, but I try to match with the files in the same directory.
I just fix the path in `boards.txt` rather than rename the file.
