### PR TITLE
[TWI] Add __attribute__ ((fallthrough)) to remove recent GCC warnings

### DIFF
--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -445,6 +445,7 @@ ISR(TWI_vect)
     case TW_MR_DATA_ACK: // data received, ack sent
       // put byte into buffer
       twi_masterBuffer[twi_masterBufferIndex++] = TWDR;
+      __attribute__ ((fallthrough));
     case TW_MR_SLA_ACK:  // address sent, ack received
       // ack if more bytes are expected, otherwise nack
       if(twi_masterBufferIndex < twi_masterBufferLength){
@@ -530,6 +531,7 @@ ISR(TWI_vect)
         twi_txBufferLength = 1;
         twi_txBuffer[0] = 0x00;
       }
+      __attribute__ ((fallthrough));		  
       // transmit first byte from buffer, fall
     case TW_ST_DATA_ACK: // byte sent, ack returned
       // copy data to output register


### PR DESCRIPTION
Added:
` __attribute__ ((fallthrough));`

Reason:
 

> warning: this statement may fall through [-Wimplicit-fallthrough=]