### PR TITLE
add overload of ::new for placement support

### DIFF
--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -22,6 +22,10 @@ void *operator new(size_t size) {
   return malloc(size);
 }
 
+void *operator new(size_t size, void *ptr) {
+  return ptr;
+}
+
 void *operator new[](size_t size) {
   return malloc(size);
 }

--- a/cores/arduino/new.h
+++ b/cores/arduino/new.h
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 
 void * operator new(size_t size);
+void * operator new(size_t size, void *ptr);
 void * operator new[](size_t size);
 void operator delete(void * ptr);
 void operator delete[](void * ptr);


### PR DESCRIPTION
This adds an overload of `::new` that matches the signature required for placement `new`. For additional background, [here's what cppreference has to say about placement new](https://en.cppreference.com/w/cpp/language/new#Placement_new).

When a programmer calls `new Foo` the existing overload of `new` is called which uses `malloc` to provide the required amount of memory. To use placement, the programmer calls `new(ptr) Foo` where `ptr` is a correctly aligned pointer to sufficient unused memory to hold an instance of `Foo`. The overload added in this PR is called which returns the passed in pointer to be used as the address of the newly created object.

To destroy an object allocated with placement new call its destructor explicitly: `fooPtr->~Foo()`. There is no corresponding "placement delete".

The following is a trivial example of placement new in action:

    void *ptr = malloc(sizeof(Foo))
    Foo *fooPtr = new(ptr) Foo;
    fooPtr->~Foo();
    free(ptr);