### PR TITLE
Adding parenthesis around 'bitvalue' allowing correct macro expansion ...

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -111,7 +111,7 @@ void yield(void);
 #define bitRead(value, bit) (((value) >> (bit)) & 0x01)
 #define bitSet(value, bit) ((value) |= (1UL << (bit)))
 #define bitClear(value, bit) ((value) &= ~(1UL << (bit)))
-#define bitWrite(value, bit, bitvalue) (bitvalue ? bitSet(value, bit) : bitClear(value, bit))
+#define bitWrite(value, bit, bitvalue) ((bitvalue) ? bitSet(value, bit) : bitClear(value, bit))
 
 // avr-libc defines _NOP() since 1.6.2
 #ifndef _NOP


### PR DESCRIPTION
... when using with ternary operator such as `bitWrite(value, bit, some_computed_value == 5 ? 1: 0);`. Fixes #105 .