### PR TITLE
Allow "update" to be used for EERef's operator=

### DIFF
--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -44,7 +44,7 @@ struct EERef{
     
     //Assignment/write members.
     EERef &operator=( const EERef &ref ) { return *this = *ref; }
-    EERef &operator=( uint8_t in )       { return eeprom_write_byte( (uint8_t*) index, in ), *this;  }
+    EERef &operator=( uint8_t in )       { return do_update ? update( in ) : write( in ); }
     EERef &operator +=( uint8_t in )     { return *this = **this + in; }
     EERef &operator -=( uint8_t in )     { return *this = **this - in; }
     EERef &operator *=( uint8_t in )     { return *this = **this * in; }
@@ -56,7 +56,8 @@ struct EERef{
     EERef &operator <<=( uint8_t in )    { return *this = **this << in; }
     EERef &operator >>=( uint8_t in )    { return *this = **this >> in; }
     
-    EERef &update( uint8_t in )          { return  in != *this ? *this = in : *this; }
+    EERef &update( uint8_t in )          { return  in != *this ? write( in ) : *this; }
+    EERef &write( uint8_t in )           { return eeprom_write_byte( (uint8_t*) index, in ), *this; }
     
     /** Prefix increment/decrement **/
     EERef& operator++()                  { return *this += 1; }
@@ -74,7 +75,9 @@ struct EERef{
     }
     
     int index; //Index of current EEPROM cell.
+    static bool do_update;
 };
+bool EERef::do_update = true;
 
 /***
     EEPtr class.
@@ -118,7 +121,7 @@ struct EEPROMClass{
     //Basic user access methods.
     EERef operator[]( const int idx )    { return idx; }
     uint8_t read( int idx )              { return EERef( idx ); }
-    void write( int idx, uint8_t val )   { (EERef( idx )) = val; }
+    void write( int idx, uint8_t val )   { EERef( idx ).write( val ); }
     void update( int idx, uint8_t val )  { EERef( idx ).update( val ); }
     
     //STL and C++11 iteration capability.

--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -56,8 +56,8 @@ struct EERef{
     EERef &operator <<=( uint8_t in )    { return *this = **this << in; }
     EERef &operator >>=( uint8_t in )    { return *this = **this >> in; }
     
-    EERef &update( uint8_t in )          { return  in != *this ? write( in ) : *this; }
-    EERef &write( uint8_t in )           { return eeprom_write_byte( (uint8_t*) index, in ), *this; }
+    EERef &update( uint8_t in )          { return  in != *this ? write( in ) : in; }
+    EERef &write( uint8_t in )           { return eeprom_write_byte( (uint8_t*) index, in ), in; }
     
     /** Prefix increment/decrement **/
     EERef& operator++()                  { return *this += 1; }


### PR DESCRIPTION
As one of the new convenience features introduced in EEPROM 2.0, `EEPROM[x] = newval` stands out from the `put` function by not using an `update` behavior. This commit allows users to use the feature while saving EEPROM lifetime by using an `update` behavior instead. It is enabled by default with a run-time switch; tests show that g++ is perfectly capable of removing the test when the result is deterministic.

For disambiguation and ease of switching, an explicit `write` function is added to EERef. Like `update`, the separate function is accepted by the compiler with an implicit `inline`. As a result, it is unlikely to adversely impact performance by going through this function instead of a direct `eeprom_write_byte`.

forum-thread: https://forum.arduino.cc/index.php?topic=542365

Migrated from arduino/Arduino#7486.

* * *
One currently pending change is the replacement of the get/put loop with corresponding avr-libc eeprom_OP_block functions, and potentially the replacement of the EERef::update method body with eeprom_update_byte. The block write and the update routines are just wrappers around eeprom_OP_r18 (body section of eeprom_OP_byte after moving a register), so the increase in code size should be minimal. On the other hand this also means the two changes would be mostly aesthetic.

eeprom_read_block is self-contained, likely because it does not take too many instructions to read. eeprom_update_byte does not reference eeprom_read_byte, but references eeprom_write_r18.