### PR TITLE
Use consistent indentation in twi.c

### DIFF
--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -40,8 +40,8 @@
 
 static volatile uint8_t twi_state;
 static volatile uint8_t twi_slarw;
-static volatile uint8_t twi_sendStop;			// should the transaction end with a stop
-static volatile uint8_t twi_inRepStart;			// in the middle of a repeated start
+static volatile uint8_t twi_sendStop;     // should the transaction end with a stop
+static volatile uint8_t twi_inRepStart;   // in the middle of a repeated start
 
 static void (*twi_onSlaveTransmit)(void);
 static void (*twi_onSlaveReceive)(uint8_t*, int);
@@ -59,7 +59,7 @@ static volatile uint8_t twi_rxBufferIndex;
 
 static volatile uint8_t twi_error;
 
-/* 
+/*
  * Function twi_init
  * Desc     readys twi pins and sets twi bitrate
  * Input    none
@@ -69,9 +69,9 @@ void twi_init(void)
 {
   // initialize state
   twi_state = TWI_READY;
-  twi_sendStop = true;		// default value
+  twi_sendStop = true;         // default value
   twi_inRepStart = false;
-  
+
   // activate internal pullups for twi.
   digitalWrite(SDA, 1);
   digitalWrite(SCL, 1);
@@ -90,7 +90,7 @@ void twi_init(void)
   TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWEA);
 }
 
-/* 
+/*
  * Function twi_disable
  * Desc     disables twi pins
  * Input    none
@@ -106,7 +106,7 @@ void twi_disable(void)
   digitalWrite(SCL, 0);
 }
 
-/* 
+/*
  * Function twi_slaveInit
  * Desc     sets slave address and enables interrupt
  * Input    none
@@ -118,7 +118,7 @@ void twi_setAddress(uint8_t address)
   TWAR = address << 1;
 }
 
-/* 
+/*
  * Function twi_setClock
  * Desc     sets twi bit rate
  * Input    Clock Frequency
@@ -127,14 +127,14 @@ void twi_setAddress(uint8_t address)
 void twi_setFrequency(uint32_t frequency)
 {
   TWBR = ((F_CPU / frequency) - 16) / 2;
-  
+
   /* twi bit rate formula from atmega128 manual pg 204
   SCL Frequency = CPU Clock Frequency / (16 + (2 * TWBR))
   note: TWBR should be 10 or higher for master mode
   It is 72 for a 16mhz Wiring board with 100kHz TWI */
 }
 
-/* 
+/*
  * Function twi_readFrom
  * Desc     attempts to become twi bus master and read a
  *          series of bytes from a device on the bus
@@ -166,7 +166,7 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
   twi_masterBufferIndex = 0;
   twi_masterBufferLength = length-1;  // This is not intuitive, read on...
   // On receive, the previously configured ACK/NACK setting is transmitted in
-  // response to the received byte before the interrupt is signalled. 
+  // response to the received byte before the interrupt is signalled.
   // Therefor we must actually set NACK when the _next_ to last byte is
   // received, causing that NACK to be sent in response to receiving the last
   // expected byte of data.
@@ -180,13 +180,13 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
     // (@@@ we hope), and the TWI statemachine is just waiting for the address byte.
     // We need to remove ourselves from the repeated start state before we enable interrupts,
     // since the ISR is ASYNC, and we could get confused if we hit the ISR before cleaning
-    // up. Also, don't enable the START interrupt. There may be one pending from the 
+    // up. Also, don't enable the START interrupt. There may be one pending from the
     // repeated start that we sent ourselves, and that would really confuse things.
-    twi_inRepStart = false;			// remember, we're dealing with an ASYNC ISR
+    twi_inRepStart = false;                    // remember, we're dealing with an ASYNC ISR
     do {
       TWDR = twi_slarw;
     } while(TWCR & _BV(TWWC));
-    TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE);	// enable INTs, but not START
+    TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE);     // enable INTs, but not START
   }
   else
     // send start condition
@@ -204,11 +204,11 @@ uint8_t twi_readFrom(uint8_t address, uint8_t* data, uint8_t length, uint8_t sen
   for(i = 0; i < length; ++i){
     data[i] = twi_masterBuffer[i];
   }
-	
+
   return length;
 }
 
-/* 
+/*
  * Function twi_writeTo
  * Desc     attempts to become twi bus master and write a
  *          series of bytes to a device on the bus
@@ -244,16 +244,16 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
   // initialize buffer iteration vars
   twi_masterBufferIndex = 0;
   twi_masterBufferLength = length;
-  
+
   // copy data to twi buffer
   for(i = 0; i < length; ++i){
     twi_masterBuffer[i] = data[i];
   }
-  
+
   // build sla+w, slave device address + w bit
   twi_slarw = TW_WRITE;
   twi_slarw |= address << 1;
-  
+
   // if we're in a repeated start, then we've already sent the START
   // in the ISR. Don't do it again.
   //
@@ -262,34 +262,34 @@ uint8_t twi_writeTo(uint8_t address, uint8_t* data, uint8_t length, uint8_t wait
     // (@@@ we hope), and the TWI statemachine is just waiting for the address byte.
     // We need to remove ourselves from the repeated start state before we enable interrupts,
     // since the ISR is ASYNC, and we could get confused if we hit the ISR before cleaning
-    // up. Also, don't enable the START interrupt. There may be one pending from the 
+    // up. Also, don't enable the START interrupt. There may be one pending from the
     // repeated start that we sent outselves, and that would really confuse things.
-    twi_inRepStart = false;			// remember, we're dealing with an ASYNC ISR
+    twi_inRepStart = false;                    // remember, we're dealing with an ASYNC ISR
     do {
-      TWDR = twi_slarw;				
+      TWDR = twi_slarw;
     } while(TWCR & _BV(TWWC));
-    TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE);	// enable INTs, but not START
+    TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE);     // enable INTs, but not START
   }
   else
     // send start condition
-    TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE) | _BV(TWSTA);	// enable INTs
+    TWCR = _BV(TWINT) | _BV(TWEA) | _BV(TWEN) | _BV(TWIE) | _BV(TWSTA);        // enable INTs
 
   // wait for write operation to complete
   while(wait && (TWI_MTX == twi_state)){
     continue;
   }
-  
+
   if (twi_error == 0xFF)
-    return 0;	// success
+    return 0;  // success
   else if (twi_error == TW_MT_SLA_NACK)
-    return 2;	// error: address send, nack received
+    return 2;  // error: address send, nack received
   else if (twi_error == TW_MT_DATA_NACK)
-    return 3;	// error: data send, nack received
+    return 3;  // error: data send, nack received
   else
-    return 4;	// other twi error
+    return 4;  // other twi error
 }
 
-/* 
+/*
  * Function twi_transmit
  * Desc     fills slave tx buffer with data
  *          must be called in slave tx event callback
@@ -307,22 +307,22 @@ uint8_t twi_transmit(const uint8_t* data, uint8_t length)
   if(TWI_BUFFER_LENGTH < (twi_txBufferLength+length)){
     return 1;
   }
-  
+
   // ensure we are currently a slave transmitter
   if(TWI_STX != twi_state){
     return 2;
   }
-  
+
   // set length and copy data into tx buffer
   for(i = 0; i < length; ++i){
     twi_txBuffer[twi_txBufferLength+i] = data[i];
   }
   twi_txBufferLength += length;
-  
+
   return 0;
 }
 
-/* 
+/*
  * Function twi_attachSlaveRxEvent
  * Desc     sets function called before a slave read operation
  * Input    function: callback function to use
@@ -333,7 +333,7 @@ void twi_attachSlaveRxEvent( void (*function)(uint8_t*, int) )
   twi_onSlaveReceive = function;
 }
 
-/* 
+/*
  * Function twi_attachSlaveTxEvent
  * Desc     sets function called before a slave write operation
  * Input    function: callback function to use
@@ -344,7 +344,7 @@ void twi_attachSlaveTxEvent( void (*function)(void) )
   twi_onSlaveTransmit = function;
 }
 
-/* 
+/*
  * Function twi_reply
  * Desc     sends byte or readys receive line
  * Input    ack: byte indicating to ack or to nack
@@ -356,11 +356,11 @@ void twi_reply(uint8_t ack)
   if(ack){
     TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWINT) | _BV(TWEA);
   }else{
-	  TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWINT);
+    TWCR = _BV(TWEN) | _BV(TWIE) | _BV(TWINT);
   }
 }
 
-/* 
+/*
  * Function twi_stop
  * Desc     relinquishes bus master status
  * Input    none
@@ -381,7 +381,7 @@ void twi_stop(void)
   twi_state = TWI_READY;
 }
 
-/* 
+/*
  * Function twi_releaseBus
  * Desc     releases bus control
  * Input    none
@@ -410,22 +410,22 @@ ISR(TWI_vect)
     // Master Transmitter
     case TW_MT_SLA_ACK:  // slave receiver acked address
     case TW_MT_DATA_ACK: // slave receiver acked data
-      // if there is data to send, send it, otherwise stop 
+      // if there is data to send, send it, otherwise stop
       if(twi_masterBufferIndex < twi_masterBufferLength){
         // copy data to output register and ack
         TWDR = twi_masterBuffer[twi_masterBufferIndex++];
         twi_reply(1);
       }else{
-	if (twi_sendStop)
+        if (twi_sendStop)
           twi_stop();
-	else {
-	  twi_inRepStart = true;	// we're gonna send the START
-	  // don't enable the interrupt. We'll generate the start, but we 
-	  // avoid handling the interrupt until we're in the next transaction,
-	  // at the point where we would normally issue the start.
-	  TWCR = _BV(TWINT) | _BV(TWSTA)| _BV(TWEN) ;
-	  twi_state = TWI_READY;
-	}
+        else {
+          twi_inRepStart = true;        // we're gonna send the START
+          // don't enable the interrupt. We'll generate the start, but we
+          // avoid handling the interrupt until we're in the next transaction,
+          // at the point where we would normally issue the start.
+          TWCR = _BV(TWINT) | _BV(TWSTA)| _BV(TWEN) ;
+          twi_state = TWI_READY;
+        }
       }
       break;
     case TW_MT_SLA_NACK:  // address sent, nack received
@@ -457,17 +457,17 @@ ISR(TWI_vect)
     case TW_MR_DATA_NACK: // data received, nack sent
       // put final byte into buffer
       twi_masterBuffer[twi_masterBufferIndex++] = TWDR;
-	if (twi_sendStop)
-          twi_stop();
-	else {
-	  twi_inRepStart = true;	// we're gonna send the START
-	  // don't enable the interrupt. We'll generate the start, but we 
-	  // avoid handling the interrupt until we're in the next transaction,
-	  // at the point where we would normally issue the start.
-	  TWCR = _BV(TWINT) | _BV(TWSTA)| _BV(TWEN) ;
-	  twi_state = TWI_READY;
-	}    
-	break;
+      if (twi_sendStop)
+        twi_stop();
+      else {
+        twi_inRepStart = true;        // we're gonna send the START
+        // don't enable the interrupt. We'll generate the start, but we
+        // avoid handling the interrupt until we're in the next transaction,
+        // at the point where we would normally issue the start.
+        TWCR = _BV(TWINT) | _BV(TWSTA)| _BV(TWEN) ;
+        twi_state = TWI_READY;
+      }
+      break;
     case TW_MR_SLA_NACK: // address sent, nack received
       twi_stop();
       break;
@@ -513,7 +513,7 @@ ISR(TWI_vect)
       // nack back at master
       twi_reply(0);
       break;
-    
+
     // Slave Transmitter
     case TW_ST_SLA_ACK:          // addressed, returned ack
     case TW_ST_ARB_LOST_SLA_ACK: // arbitration lost, returned ack
@@ -531,7 +531,7 @@ ISR(TWI_vect)
         twi_txBufferLength = 1;
         twi_txBuffer[0] = 0x00;
       }
-      __attribute__ ((fallthrough));		  
+      __attribute__ ((fallthrough));
       // transmit first byte from buffer, fall
     case TW_ST_DATA_ACK: // byte sent, ack returned
       // copy data to output register
@@ -543,7 +543,7 @@ ISR(TWI_vect)
         twi_reply(0);
       }
       break;
-    case TW_ST_DATA_NACK: // received nack, we are done 
+    case TW_ST_DATA_NACK: // received nack, we are done
     case TW_ST_LAST_DATA: // received ack, but we are done already!
       // ack future responses
       twi_reply(1);


### PR DESCRIPTION
- Use always spaces instead of tabs, it seems the style of the file is
  to use generally 2 spaces for indent, while tabs of 8 spaces are
  inconsistently used in the file
- Remove trailing spaces

Signed-off-by: Eddy Petrișor <eddy.petrisor@gmail.com>