### PR TITLE
Greatly reduced error rate of WMath map() roundtrip

### DIFF
--- a/cores/arduino/WMath.cpp
+++ b/cores/arduino/WMath.cpp
@@ -49,9 +49,12 @@ long random(long howsmall, long howbig)
   return random(diff) + howsmall;
 }
 
-long map(long x, long in_min, long in_max, long out_min, long out_max)
-{
-  return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+long map(long x, long in_min, long in_max, long out_min, long out_max) {
+  const long dividend = out_max - out_min;
+  const long divisor = in_max - in_min;
+  const long delta = x - in_min;
+
+  return (delta * dividend + (divisor / 2)) / divisor + out_min;
 }
 
 unsigned int makeWord(unsigned int w) { return w; }

--- a/cores/arduino/WMath.cpp
+++ b/cores/arduino/WMath.cpp
@@ -49,7 +49,10 @@ long random(long howsmall, long howbig)
   return random(diff) + howsmall;
 }
 
-long map(long x, long in_min, long in_max, long out_min, long out_max) {
+// well-defined for in_min < in_max, in_min <= x <= in_max,
+// out_min <= out_max
+long map(long x, long in_min, long in_max, long out_min, long out_max)
+{
   const long dividend = out_max - out_min;
   const long divisor = in_max - in_min;
   const long delta = x - in_min;


### PR DESCRIPTION
Half, or zero errors, depending on in/out…… ranges, for round-trip mapping at the same performance.
(Based on "improved_map" from ESP8266's Servo.cpp)