### PR TITLE
Fix sine -> since typo in HardwareSerial files

### DIFF
--- a/cores/arduino/HardwareSerial0.cpp
+++ b/cores/arduino/HardwareSerial0.cpp
@@ -26,7 +26,7 @@
 #include "HardwareSerial.h"
 #include "HardwareSerial_private.h"
 
-// Each HardwareSerial is defined in its own file, sine the linker pulls
+// Each HardwareSerial is defined in its own file, since the linker pulls
 // in the entire file when any element inside is used. --gc-sections can
 // additionally cause unused symbols to be dropped, but ISRs have the
 // "used" attribute so are never dropped and they keep the

--- a/cores/arduino/HardwareSerial1.cpp
+++ b/cores/arduino/HardwareSerial1.cpp
@@ -26,7 +26,7 @@
 #include "HardwareSerial.h"
 #include "HardwareSerial_private.h"
 
-// Each HardwareSerial is defined in its own file, sine the linker pulls
+// Each HardwareSerial is defined in its own file, since the linker pulls
 // in the entire file when any element inside is used. --gc-sections can
 // additionally cause unused symbols to be dropped, but ISRs have the
 // "used" attribute so are never dropped and they keep the

--- a/cores/arduino/HardwareSerial2.cpp
+++ b/cores/arduino/HardwareSerial2.cpp
@@ -26,7 +26,7 @@
 #include "HardwareSerial.h"
 #include "HardwareSerial_private.h"
 
-// Each HardwareSerial is defined in its own file, sine the linker pulls
+// Each HardwareSerial is defined in its own file, since the linker pulls
 // in the entire file when any element inside is used. --gc-sections can
 // additionally cause unused symbols to be dropped, but ISRs have the
 // "used" attribute so are never dropped and they keep the

--- a/cores/arduino/HardwareSerial3.cpp
+++ b/cores/arduino/HardwareSerial3.cpp
@@ -26,7 +26,7 @@
 #include "HardwareSerial.h"
 #include "HardwareSerial_private.h"
 
-// Each HardwareSerial is defined in its own file, sine the linker pulls
+// Each HardwareSerial is defined in its own file, since the linker pulls
 // in the entire file when any element inside is used. --gc-sections can
 // additionally cause unused symbols to be dropped, but ISRs have the
 // "used" attribute so are never dropped and they keep the


### PR DESCRIPTION
One character typo in a documentation comment, repeated across a couple files.

Stumbled onto this while browsing the code.