### PR TITLE
Add --relax linker option

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -21,7 +21,7 @@ compiler.warning_flags.all=-Wall -Wextra
 compiler.path={runtime.tools.avr-gcc.path}/bin/
 compiler.c.cmd=avr-gcc
 compiler.c.flags=-c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -MMD -flto -fno-fat-lto-objects
-compiler.c.elf.flags={compiler.warning_flags} -Os -g -flto -fuse-linker-plugin -Wl,--gc-sections
+compiler.c.elf.flags={compiler.warning_flags} -Os -g -flto -fuse-linker-plugin -Wl,--gc-sections -Wl,--relax
 compiler.c.elf.cmd=avr-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp -flto -MMD
 compiler.cpp.cmd=avr-g++


### PR DESCRIPTION
This is currently automatically added by arduino-builder/arduino-cli,
but it should really be made explicit in the platform definition. This
allows removing it from arduino-cli later, see https://github.com/arduino/arduino-cli/issues/639

This option tells the linker to replace "call" instructions by "rcall"
instructions where possible. This option was only automatically added
for the atmega2560, but it is actually useful for any ATmega with > 8K
flash (and a no-op for boards with <= 8K flash), so it can be added to
the commandline unconditionally.

This was tested on a Uno board (which saves a few bytes on the empty
sketch) and an Arduino NG with atmega8, which also accepts the option
but as expected it does not make a difference in sketch size.

Because this option is added at the end, it does not conflict with the
automatically added option (the linker commandline just gets
`-Wl,--relax,--relax` which works fine.