### PR TITLE
Fix off-by-one in shiftIn function

### DIFF
--- a/cores/arduino/wiring_shift.c
+++ b/cores/arduino/wiring_shift.c
@@ -26,7 +26,7 @@ uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder) {
 	uint8_t value = 0;
 	uint8_t i;
 
-	for (i = 0; i < 8; ++i) {
+	for (i = 0; i < 8; i++) {
 		digitalWrite(clockPin, HIGH);
 		if (bitOrder == LSBFIRST)
 			value |= digitalRead(dataPin) << i;


### PR DESCRIPTION
This bug exists in the following arduino cores as well (probably all of the arduino cores?):
- [NRF52](https://github.com/adafruit/Adafruit_nRF52_Arduino) - Opened an [MR](https://github.com/adafruit/Adafruit_nRF52_Arduino/pull/493)
- [ESP8266](https://github.com/esp8266/Arduino)
- [ESP32](https://github.com/espressif/arduino-esp32)