### PR TITLE
Improved USB ZLP logic to support long bulk transfers

### DIFF
--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -318,14 +318,14 @@ int USB_Send(u8 ep, const void* d, int len)
 					if (ep & TRANSFER_RELEASE) {
 						sendZlp = true;
 					} else {
-						_usbZlpPending[ep] = 1;
+						_usbZlpPending[ep & 7] = 1;
 					}
 				}
 			} else if ((len == 0) && (ep & TRANSFER_RELEASE)) { // ...or if forced with TRANSFER_RELEASE
 				ReleaseTX();
-				_usbZlpPending[ep] = 0;
+				_usbZlpPending[ep & 7] = 0;
 			} else {
-				_usbZlpPending[ep] = 0;
+				_usbZlpPending[ep & 7] = 0;
 			}
 		}
 	}
@@ -656,9 +656,9 @@ ISR(USB_COM_vect)
 void USB_Flush(u8 ep)
 {
 	LockEP lock(ep);
-	if (FifoByteCount() || _usbZlpPending[ep]) {
+	if (FifoByteCount() || _usbZlpPending[ep & 7]) {
 		ReleaseTX();
-		_usbZlpPending[ep] = 0;
+		_usbZlpPending[ep & 7] = 0;
 	}
 }
 

--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -78,6 +78,7 @@ const DeviceDescriptor USB_DeviceDescriptorIAD =
 volatile u8 _usbConfiguration = 0;
 volatile u8 _usbCurrentStatus = 0; // meaning of bits see usb_20.pdf, Figure 9-4. Information Returned by a GetStatus() Request to a Device
 volatile u8 _usbSuspendState = 0; // copy of UDINT to check SUSPI and WAKEUPI bits
+volatile u8 _usbZlpPending[USB_ENDPOINTS] = {0};
 
 static inline void WaitIN(void)
 {
@@ -313,10 +314,18 @@ int USB_Send(u8 ep, const void* d, int len)
 				sendZlp = false;
 			} else if (!ReadWriteAllowed()) { // ...release if buffer is full...
 				ReleaseTX();
-				if (len == 0) sendZlp = true;
+				if (len == 0) {
+					if (ep & TRANSFER_RELEASE) {
+						sendZlp = true;
+					} else {
+						_usbZlpPending[ep] = 1;
+					}
+				}
 			} else if ((len == 0) && (ep & TRANSFER_RELEASE)) { // ...or if forced with TRANSFER_RELEASE
-				// XXX: TRANSFER_RELEASE is never used can be removed?
 				ReleaseTX();
+				_usbZlpPending[ep] = 0;
+			} else {
+				_usbZlpPending[ep] = 0;
 			}
 		}
 	}
@@ -646,9 +655,11 @@ ISR(USB_COM_vect)
 
 void USB_Flush(u8 ep)
 {
-	SetEP(ep);
-	if (FifoByteCount())
+	LockEP lock(ep);
+	if (FifoByteCount() || _usbZlpPending[ep]) {
 		ReleaseTX();
+		_usbZlpPending[ep] = 0;
+	}
 }
 
 static inline void USB_ClockDisable()
@@ -811,6 +822,7 @@ void USBDevice_::attach()
 	_usbConfiguration = 0;
 	_usbCurrentStatus = 0;
 	_usbSuspendState = 0;
+	memset((void *)_usbZlpPending, 0, sizeof(_usbZlpPending));
 	USB_ClockEnable();
 
 	UDINT &= ~((1<<WAKEUPI) | (1<<SUSPI)); // clear already pending WAKEUP / SUSPEND requests


### PR DESCRIPTION
I suggest following improvement in USB zero length packet logic. The reason for this is to support bulk transfers over 64 bytes without interrupting by ZLP. This is necessary for example for USB mass storage which I am currently developing. Master might starts a read command with the length exceeding Arduino memory capacity. In that case data needs to be retrieved from storage and sent to USB in chunks. Current implementation of USB core sends ZLP when the end of chunk is aligned to 64 bytes block. This terminates the bulk transfer and causes error in host driver. I tried to fix this in a way which does not affect CDC and HID. I have tested both CDC and HID on Linux. I also checked with a logic analyzer and USB communication seems fine to me.