### PR TITLE
Add "new" proxy header for compatibility with c++-standard #include<new>

### DIFF
--- a/cores/arduino/new
+++ b/cores/arduino/new
@@ -1,0 +1,5 @@
+/*
+this header is for compatibility with standard c++ header names
+so that #include<new> works as expected
+*/
+#include "new.h"


### PR DESCRIPTION
See discussion in https://github.com/ETLCPP/etl/issues/222#issuecomment-627615713 (breakage of ETL as #include<new> fails).