### PR TITLE
Fixing useless waste of memory

### DIFF
--- a/cores/arduino/wiring_digital.c
+++ b/cores/arduino/wiring_digital.c
@@ -162,7 +162,7 @@ void digitalWrite(uint8_t pin, uint8_t val)
 	SREG = oldSREG;
 }
 
-int digitalRead(uint8_t pin)
+boolean digitalRead(uint8_t pin)
 {
 	uint8_t timer = digitalPinToTimer(pin);
 	uint8_t bit = digitalPinToBitMask(pin);


### PR DESCRIPTION
Since digitaRead only returns either HIGH or LOW, it would make more sense to return a bool instead of an int.