### PR TITLE
Improve and complete implementation of new/delete

### DIFF
--- a/cores/arduino/abi.cpp
+++ b/cores/arduino/abi.cpp
@@ -28,14 +28,9 @@ namespace std {
 }
 
 void __cxa_pure_virtual(void) {
-  // We might want to write some diagnostics to uart in this case
-  //std::terminate();
-  abort();
+  std::terminate();
 }
 
 void __cxa_deleted_virtual(void) {
-  // We might want to write some diagnostics to uart in this case
-  //std::terminate();
-  abort();
+  std::terminate();
 }
-

--- a/cores/arduino/abi.cpp
+++ b/cores/arduino/abi.cpp
@@ -21,6 +21,12 @@
 extern "C" void __cxa_pure_virtual(void) __attribute__ ((__noreturn__));
 extern "C" void __cxa_deleted_virtual(void) __attribute__ ((__noreturn__));
 
+namespace std {
+  [[gnu::weak, noreturn]] void terminate() {
+    abort();
+  }
+}
+
 void __cxa_pure_virtual(void) {
   // We might want to write some diagnostics to uart in this case
   //std::terminate();

--- a/cores/arduino/new
+++ b/cores/arduino/new
@@ -1,5 +1,31 @@
 /*
-this header is for compatibility with standard c++ header names
-so that #include<new> works as expected
+  Copyright (c) 2014 Arduino.  All right reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
-#include "new.h"
+
+#ifndef NEW_H
+#define NEW_H
+
+#include <stdlib.h>
+
+void * operator new(size_t size);
+void * operator new[](size_t size);
+void * operator new(size_t size, void * ptr) noexcept;
+void operator delete(void * ptr);
+void operator delete[](void * ptr);
+
+#endif
+

--- a/cores/arduino/new
+++ b/cores/arduino/new
@@ -31,23 +31,29 @@ namespace std {
   typedef void (*new_handler)();
   new_handler set_new_handler(new_handler new_p) noexcept;
   new_handler get_new_handler() noexcept;
+
+  // This is normally declared in various headers that we do not have
+  // available, so just define it here. We could also use ::size_t
+  // below, but then anyone including <new> can no longer assume
+  // std::size_t is available.
+  using size_t = ::size_t;
 } // namespace std
 
-[[gnu::weak]] void * operator new(size_t size);
-[[gnu::weak]] void * operator new[](size_t size);
+[[gnu::weak]] void * operator new(std::size_t size);
+[[gnu::weak]] void * operator new[](std::size_t size);
 
-[[gnu::weak]] void * operator new(size_t size, const std::nothrow_t tag) noexcept;
-[[gnu::weak]] void * operator new[](size_t size, const std::nothrow_t& tag) noexcept;
+[[gnu::weak]] void * operator new(std::size_t size, const std::nothrow_t tag) noexcept;
+[[gnu::weak]] void * operator new[](std::size_t size, const std::nothrow_t& tag) noexcept;
 
-void * operator new(size_t size, void *place) noexcept;
-void * operator new[](size_t size, void *place) noexcept;
+void * operator new(std::size_t size, void *place) noexcept;
+void * operator new[](std::size_t size, void *place) noexcept;
 
 [[gnu::weak]] void operator delete(void * ptr) noexcept;
 [[gnu::weak]] void operator delete[](void * ptr) noexcept;
 
 #if __cplusplus >= 201402L
-[[gnu::weak]] void operator delete(void* ptr, size_t size) noexcept;
-[[gnu::weak]] void operator delete[](void * ptr, size_t size) noexcept;
+[[gnu::weak]] void operator delete(void* ptr, std::size_t size) noexcept;
+[[gnu::weak]] void operator delete[](void * ptr, std::size_t size) noexcept;
 #endif // __cplusplus >= 201402L
 
 [[gnu::weak]] void operator delete(void* ptr, const std::nothrow_t& tag) noexcept;

--- a/cores/arduino/new
+++ b/cores/arduino/new
@@ -21,11 +21,40 @@
 
 #include <stdlib.h>
 
+namespace std {
+  struct nothrow_t {};
+  extern const nothrow_t nothrow;
+
+  // These are not actually implemented, to prevent overhead and
+  // complexity. They are still declared to allow implementing
+  // them in user code if needed.
+  typedef void (*new_handler)();
+  new_handler set_new_handler(new_handler new_p) noexcept;
+  new_handler get_new_handler() noexcept;
+} // namespace std
+
 void * operator new(size_t size);
 void * operator new[](size_t size);
-void * operator new(size_t size, void * ptr) noexcept;
-void operator delete(void * ptr);
-void operator delete[](void * ptr);
+
+void * operator new(size_t size, const std::nothrow_t tag) noexcept;
+void * operator new[](size_t size, const std::nothrow_t& tag) noexcept;
+
+void * operator new(size_t size, void *place) noexcept;
+void * operator new[](size_t size, void *place) noexcept;
+
+void operator delete(void * ptr) noexcept;
+void operator delete[](void * ptr) noexcept;
+
+#if __cplusplus >= 201402L
+void operator delete(void* ptr, size_t size) noexcept;
+void operator delete[](void * ptr, size_t size) noexcept;
+#endif // __cplusplus >= 201402L
+
+void operator delete(void* ptr, const std::nothrow_t& tag) noexcept;
+void operator delete[](void* ptr, const std::nothrow_t& tag) noexcept;
+
+void operator delete(void* ptr, void* place) noexcept;
+void operator delete[](void* ptr, void* place) noexcept;
 
 #endif
 

--- a/cores/arduino/new
+++ b/cores/arduino/new
@@ -33,25 +33,25 @@ namespace std {
   new_handler get_new_handler() noexcept;
 } // namespace std
 
-void * operator new(size_t size);
-void * operator new[](size_t size);
+[[gnu::weak]] void * operator new(size_t size);
+[[gnu::weak]] void * operator new[](size_t size);
 
-void * operator new(size_t size, const std::nothrow_t tag) noexcept;
-void * operator new[](size_t size, const std::nothrow_t& tag) noexcept;
+[[gnu::weak]] void * operator new(size_t size, const std::nothrow_t tag) noexcept;
+[[gnu::weak]] void * operator new[](size_t size, const std::nothrow_t& tag) noexcept;
 
 void * operator new(size_t size, void *place) noexcept;
 void * operator new[](size_t size, void *place) noexcept;
 
-void operator delete(void * ptr) noexcept;
-void operator delete[](void * ptr) noexcept;
+[[gnu::weak]] void operator delete(void * ptr) noexcept;
+[[gnu::weak]] void operator delete[](void * ptr) noexcept;
 
 #if __cplusplus >= 201402L
-void operator delete(void* ptr, size_t size) noexcept;
-void operator delete[](void * ptr, size_t size) noexcept;
+[[gnu::weak]] void operator delete(void* ptr, size_t size) noexcept;
+[[gnu::weak]] void operator delete[](void * ptr, size_t size) noexcept;
 #endif // __cplusplus >= 201402L
 
-void operator delete(void* ptr, const std::nothrow_t& tag) noexcept;
-void operator delete[](void* ptr, const std::nothrow_t& tag) noexcept;
+[[gnu::weak]] void operator delete(void* ptr, const std::nothrow_t& tag) noexcept;
+[[gnu::weak]] void operator delete[](void* ptr, const std::nothrow_t& tag) noexcept;
 
 void operator delete(void* ptr, void* place) noexcept;
 void operator delete[](void* ptr, void* place) noexcept;

--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -16,26 +16,63 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <stdlib.h>
+#include "new.h"
 
-void *operator new(size_t size) {
+namespace std {
+  const nothrow_t nothrow;
+}
+
+void * operator new(size_t size) {
   return malloc(size);
 }
-
-void *operator new[](size_t size) {
-  return malloc(size);
+void * operator new[](size_t size) {
+  return operator new(size);
 }
 
-void * operator new(size_t size, void * ptr) noexcept {
-  (void)size;
-  return ptr;
+void * operator new(size_t size, const std::nothrow_t tag) noexcept {
+  return operator new(size);
+}
+void * operator new[](size_t size, const std::nothrow_t& tag) noexcept {
+  return operator new[](size);
 }
 
-void operator delete(void * ptr) {
+void * operator new(size_t size, void *place) noexcept {
+  // Nothing to do
+  (void)size; // unused
+  return place;
+}
+void * operator new[](size_t size, void *place) noexcept {
+  return operator new(size, place);
+}
+
+void operator delete(void * ptr) noexcept {
   free(ptr);
 }
-
-void operator delete[](void * ptr) {
-  free(ptr);
+void operator delete[](void * ptr) noexcept {
+  operator delete(ptr);
 }
 
+#if __cplusplus >= 201402L
+void operator delete(void* ptr, size_t size) noexcept {
+  operator delete(ptr);
+}
+void operator delete[](void * ptr, size_t size) noexcept {
+  operator delete[](ptr);
+}
+#endif // __cplusplus >= 201402L
+
+void operator delete(void* ptr, const std::nothrow_t& tag) noexcept {
+  operator delete(ptr);
+}
+void operator delete[](void* ptr, const std::nothrow_t& tag) noexcept {
+  operator delete[](ptr);
+}
+
+void operator delete(void* ptr, void* place) noexcept {
+  (void)ptr; (void)place; // unused
+  // Nothing to do
+}
+void operator delete[](void* ptr, void* place) noexcept {
+  (void)ptr; (void)place; // unused
+  // Nothing to do
+}

--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -18,26 +18,61 @@
 
 #include "new.h"
 
+// The C++ spec dicates that allocation failure should cause the
+// (non-nothrow version of the) operator new to throw an exception.
+// Since we expect to have exceptions disabled, it would be more
+// appropriate (and probably standards-compliant) to terminate instead.
+// Historically failure causes null to be returned, but this define
+// allows switching to more robust terminating behaviour (that might
+// become the default at some point in the future). Note that any code
+// that wants null to be returned can (and should) use the nothrow
+// versions of the new statement anyway and is unaffected by this.
+// #define NEW_TERMINATES_ON_FAILURE
+
 namespace std {
+  // Defined in abi.cpp
+  void terminate();
+
   const nothrow_t nothrow;
 }
 
-void * operator new(size_t size) {
+static void * new_helper(size_t size) {
   // Even zero-sized allocations should return a unique pointer, but
   // malloc does not guarantee this
   if (size == 0)
     size = 1;
   return malloc(size);
 }
+
+void * operator new(size_t size) {
+  void *res = new_helper(size);
+#if defined(NEW_TERMINATES_ON_FAILURE)
+  if (!res)
+    std::terminate();
+#endif
+  return res;
+}
 void * operator new[](size_t size) {
   return operator new(size);
 }
 
 void * operator new(size_t size, const std::nothrow_t tag) noexcept {
+#if defined(NEW_TERMINATES_ON_FAILURE)
+  // Cannot call throwing operator new as standard suggests, so call
+  // new_helper directly then
+  return new_helper(size);
+#else
   return operator new(size);
+#endif
 }
 void * operator new[](size_t size, const std::nothrow_t& tag) noexcept {
+#if defined(NEW_TERMINATES_ON_FAILURE)
+  // Cannot call throwing operator new[] as standard suggests, so call
+  // malloc directly then
+  return new_helper(size);
+#else
   return operator new[](size);
+#endif
 }
 
 void * operator new(size_t size, void *place) noexcept {

--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -23,6 +23,10 @@ namespace std {
 }
 
 void * operator new(size_t size) {
+  // Even zero-sized allocations should return a unique pointer, but
+  // malloc does not guarantee this
+  if (size == 0)
+    size = 1;
   return malloc(size);
 }
 void * operator new[](size_t size) {

--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -36,7 +36,7 @@ namespace std {
   const nothrow_t nothrow;
 }
 
-static void * new_helper(size_t size) {
+static void * new_helper(std::size_t size) {
   // Even zero-sized allocations should return a unique pointer, but
   // malloc does not guarantee this
   if (size == 0)
@@ -44,7 +44,7 @@ static void * new_helper(size_t size) {
   return malloc(size);
 }
 
-void * operator new(size_t size) {
+void * operator new(std::size_t size) {
   void *res = new_helper(size);
 #if defined(NEW_TERMINATES_ON_FAILURE)
   if (!res)
@@ -52,11 +52,11 @@ void * operator new(size_t size) {
 #endif
   return res;
 }
-void * operator new[](size_t size) {
+void * operator new[](std::size_t size) {
   return operator new(size);
 }
 
-void * operator new(size_t size, const std::nothrow_t tag) noexcept {
+void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new as standard suggests, so call
   // new_helper directly then
@@ -65,7 +65,7 @@ void * operator new(size_t size, const std::nothrow_t tag) noexcept {
   return operator new(size);
 #endif
 }
-void * operator new[](size_t size, const std::nothrow_t& tag) noexcept {
+void * operator new[](std::size_t size, const std::nothrow_t& tag) noexcept {
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new[] as standard suggests, so call
   // malloc directly then
@@ -75,12 +75,12 @@ void * operator new[](size_t size, const std::nothrow_t& tag) noexcept {
 #endif
 }
 
-void * operator new(size_t size, void *place) noexcept {
+void * operator new(std::size_t size, void *place) noexcept {
   // Nothing to do
   (void)size; // unused
   return place;
 }
-void * operator new[](size_t size, void *place) noexcept {
+void * operator new[](std::size_t size, void *place) noexcept {
   return operator new(size, place);
 }
 
@@ -92,10 +92,10 @@ void operator delete[](void * ptr) noexcept {
 }
 
 #if __cplusplus >= 201402L
-void operator delete(void* ptr, size_t size) noexcept {
+void operator delete(void* ptr, std::size_t size) noexcept {
   operator delete(ptr);
 }
-void operator delete[](void * ptr, size_t size) noexcept {
+void operator delete[](void * ptr, std::size_t size) noexcept {
   operator delete[](ptr);
 }
 #endif // __cplusplus >= 201402L

--- a/cores/arduino/new.h
+++ b/cores/arduino/new.h
@@ -1,31 +1,3 @@
-/*
-  Copyright (c) 2014 Arduino.  All right reserved.
-
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation; either
-  version 2.1 of the License, or (at your option) any later version.
-
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  See the GNU Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-*/
-
-#ifndef NEW_H
-#define NEW_H
-
-#include <stdlib.h>
-
-void * operator new(size_t size);
-void * operator new[](size_t size);
-void * operator new(size_t size, void * ptr) noexcept;
-void operator delete(void * ptr);
-void operator delete[](void * ptr);
-
-#endif
-
+// This file originally used a non-standard name for this Arduino core
+// only, so still expose the old new.h name for compatibility.
+#include "new"


### PR DESCRIPTION
Since #340, the Arduino core exposes a `new` header (in addition to the previously used `new.h`), but it was incomplete, causing code that previously relied on a more complete `new` header (such as provided by uclibc++) to break. This breakage, and various considerations around improving new/delete were discussed in #287.

This PR fixes this by (almost) completing the `new` header.

This also prepares for letting `new` terminate, rather than returning null on allocation failure. The standard dictates an exception should be thrown, but that is not possible on AVR, so terminating is more similar to raising an exception that is never caught (and thus probably more standards compliant). Code that needs to (portably) handle allocation failure can (after merging this PR) already start using the nothrow version of new instead of the regular one. For compatibility reasons, the code to terminate instead of returning null is disabled yet, but can be enabled using a macro now already, and should be enabled by default in the future.

This also makes some related improvements to the `__cxa_pure_virtual` and `__cxa_deleted_virtual`.

This PR fixes #287 and fixes #47.