### PR TITLE
Wire: Define WIRE_HAS_TIMEOUT

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -97,7 +97,7 @@ void TwoWire::setClock(uint32_t clock)
  * master that has claimed the bus).
  *
  * When a timeout is triggered, a flag is set that can be queried with `getWireTimeoutFlag()` and is cleared
- * when `clearWireTimeoutFlag()` or `setWireTimeoutUs()` is called.
+ * when `clearWireTimeoutFlag()` or `setWireTimeout()` is called.
  *
  * Note that this timeout can also trigger while waiting for clock stretching or waiting for a second master
  * to complete its transaction. So make sure to adapt the timeout to accomodate for those cases if needed.
@@ -105,7 +105,7 @@ void TwoWire::setClock(uint32_t clock)
  * but (much) shorter values will usually also work.
  *
  * In the future, a timeout will be enabled by default, so if you require the timeout to be disabled, it is
- * recommended you disable it by default using `setWireTimeoutUs(0)`, even though that is currently
+ * recommended you disable it by default using `setWireTimeout(0)`, even though that is currently
  * the default.
  *
  * @param timeout a timeout value in microseconds, if zero then timeout checking is disabled

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -111,7 +111,6 @@ void TwoWire::setClock(uint32_t clock)
  * @param timeout a timeout value in microseconds, if zero then timeout checking is disabled
  * @param reset_on_timeout if true then TWI interface will be automatically reset on timeout
  *                           if false then TWI interface will not be reset on timeout
-
  */
 void TwoWire::setWireTimeout(uint32_t timeout, bool reset_on_timeout){
   twi_setTimeoutInMicros(timeout, reset_on_timeout);

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -109,12 +109,12 @@ void TwoWire::setClock(uint32_t clock)
  * the default.
  *
  * @param timeout a timeout value in microseconds, if zero then timeout checking is disabled
- * @param reset_with_timeout if true then TWI interface will be automatically reset on timeout
+ * @param reset_on_timeout if true then TWI interface will be automatically reset on timeout
  *                           if false then TWI interface will not be reset on timeout
 
  */
-void TwoWire::setWireTimeout(uint32_t timeout, bool reset_with_timeout){
-  twi_setTimeoutInMicros(timeout, reset_with_timeout);
+void TwoWire::setWireTimeout(uint32_t timeout, bool reset_on_timeout){
+  twi_setTimeoutInMicros(timeout, reset_on_timeout);
 }
 
 /***

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -25,6 +25,7 @@
 
 #include <inttypes.h>
 #include "Stream.h"
+#include "utility/twi.h"
 
 #define BUFFER_LENGTH 32
 
@@ -33,6 +34,10 @@
 // WIRE_HAS_TIMEOUT means Wire has setWireTimeout(), getWireTimeoutFlag
 // and clearWireTimeoutFlag()
 #define WIRE_HAS_TIMEOUT 1
+
+// When not configured, these settings are used for the timeout
+#define WIRE_DEFAULT_TIMEOUT TWI_DEFAULT_TIMEOUT
+#define WIRE_DEFAULT_RESET_ON_TIMEOUT TWI_DEFAULT_RESET_ON_TIMEOUT
 
 class TwoWire : public Stream
 {

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -30,6 +30,9 @@
 
 // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
+// WIRE_HAS_TIMEOUT means Wire has setWireTimeout(), getWireTimeoutFlag
+// and clearWireTimeoutFlag()
+#define WIRE_HAS_TIMEOUT 1
 
 class TwoWire : public Stream
 {

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -63,7 +63,7 @@ class TwoWire : public Stream
     void begin(int);
     void end();
     void setClock(uint32_t);
-    void setWireTimeout(uint32_t timeout = 25000, bool reset_with_timeout = false);
+    void setWireTimeout(uint32_t timeout = 25000, bool reset_on_timeout = false);
     bool getWireTimeoutFlag(void);
     void clearWireTimeoutFlag(void);
     void beginTransmission(uint8_t);

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -451,13 +451,13 @@ void twi_releaseBus(void)
  * Function twi_setTimeoutInMicros
  * Desc     set a timeout for while loops that twi might get stuck in
  * Input    timeout value in microseconds (0 means never time out)
- * Input    reset_with_timeout: true causes timeout events to reset twi
+ * Input    reset_on_timeout: true causes timeout events to reset twi
  * Output   none
  */
-void twi_setTimeoutInMicros(uint32_t timeout, bool reset_with_timeout){
+void twi_setTimeoutInMicros(uint32_t timeout, bool reset_on_timeout){
   twi_timed_out_flag = false;
   twi_timeout_us = timeout;
-  twi_do_reset_on_timeout = reset_with_timeout;
+  twi_do_reset_on_timeout = reset_on_timeout;
 }
 
 /* 

--- a/libraries/Wire/src/utility/twi.c
+++ b/libraries/Wire/src/utility/twi.c
@@ -51,9 +51,9 @@ static volatile uint8_t twi_inRepStart;			// in the middle of a repeated start
 // and twi_do_reset_on_timeout could become true
 // to conform to the SMBus standard
 // http://smbus.org/specs/SMBus_3_1_20180319.pdf
-static volatile uint32_t twi_timeout_us = 0ul;
+static volatile uint32_t twi_timeout_us = TWI_DEFAULT_TIMEOUT;
 static volatile bool twi_timed_out_flag = false;  // a timeout has been seen
-static volatile bool twi_do_reset_on_timeout = false;  // reset the TWI registers on timeout
+static volatile bool twi_do_reset_on_timeout = TWI_DEFAULT_RESET_ON_TIMEOUT;  // reset the TWI registers on timeout
 
 static void (*twi_onSlaveTransmit)(void);
 static void (*twi_onSlaveReceive)(uint8_t*, int);

--- a/libraries/Wire/src/utility/twi.h
+++ b/libraries/Wire/src/utility/twi.h
@@ -34,6 +34,14 @@
   #define TWI_BUFFER_LENGTH 32
   #endif
 
+  #ifndef TWI_DEFAULT_TIMEOUT
+  #define TWI_DEFAULT_TIMEOUT 0
+  #endif
+
+  #ifndef TWI_DEFAULT_RESET_ON_TIMEOUT
+  #define TWI_DEFAULT_RESET_ON_TIMEOUT 0
+  #endif
+
   #define TWI_READY 0
   #define TWI_MRX   1
   #define TWI_MTX   2


### PR DESCRIPTION
In commit deea929 (Introduce non compulsory Wire timeout), some
timeout-related functions were added. To allow writing portable
sketches, it is important for those sketch to know whether they are
using a Wire library version that is new enough to offer these functions
without having to rely on version number checking (since other Arduino
cores have their own versioning schemes).

This adds a WIRE_HAS_TIMEOUT macro, similar to the existing WIRE_HAS_END
macro, to facilitate that.

This relates to #42.