### PR TITLE
Wire: Enable a timeout by default

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -64,6 +64,8 @@ void TwoWire::begin(void)
   twi_init();
   twi_attachSlaveTxEvent(onRequestService); // default callback must exist
   twi_attachSlaveRxEvent(onReceiveService); // default callback must exist
+
+  twi_setTimeoutInMicros(WIRE_DEFAULT_TIMEOUT, WIRE_DEFAULT_RESET_WITH_TIMEOUT);
 }
 
 void TwoWire::begin(uint8_t address)

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -34,6 +34,10 @@
 // and clearWireTimeoutFlag()
 #define WIRE_HAS_TIMEOUT 1
 
+// When not configured, these settings are used for the timeout
+#define WIRE_DEFAULT_TIMEOUT 0
+#define WIRE_DEFAULT_RESET_WITH_TIMEOUT false
+
 class TwoWire : public Stream
 {
   private:

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -30,6 +30,9 @@
 
 // WIRE_HAS_END means Wire has end()
 #define WIRE_HAS_END 1
+// WIRE_HAS_TIMEOUT means Wire has setWireTimeout(), getWireTimeoutFlag
+// and clearWireTimeoutFlag()
+#define WIRE_HAS_TIMEOUT 1
 
 class TwoWire : public Stream
 {

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -35,8 +35,8 @@
 #define WIRE_HAS_TIMEOUT 1
 
 // When not configured, these settings are used for the timeout
-#define WIRE_DEFAULT_TIMEOUT 0
-#define WIRE_DEFAULT_RESET_WITH_TIMEOUT false
+#define WIRE_DEFAULT_TIMEOUT 25000
+#define WIRE_DEFAULT_RESET_WITH_TIMEOUT true
 
 class TwoWire : public Stream
 {


### PR DESCRIPTION
When no timeout is explicitly configured, Wire now uses a timeout of
25ms, resetting the Wire hardware if a timeout occurs.

The timeout length matches the timeout you get when you call
`Wire.setWireTimeout()` without arguments, and is loosely based on the
SMBus timeout and maximum clock stretching time (though it works quite
differently) and is rather long. In practice, this means that even if
another master is on the bus, or slaves are using significant clock
stretching, the timeout will probably not trigger unless there really is
a lockup.

This also enables a reset of the Wire hardware on a timeout (unlike
`Wire.setWireTimeout()` without arguments), under the assumption that if
a sketch has not set up timeout settings explicitly, it probably just
wants things to keep running as well as possible and resetting allows
recovering from most transient lockups.

See #42 for earlier discussion of this.


As discussed before, this is not intended to be merged directly, but
only after the timeout feature has been available for a while. However,
having this PR might help not forgetting this later, and serves as a
place for discussing the exact values of the timeout already.

Note this PR also includes the commits from #362, but those should be ignored here. Only the last commit is relevant here.