### PR TITLE
Add support for the AVR-Doper programmer.

### DIFF
--- a/programmers.txt
+++ b/programmers.txt
@@ -113,3 +113,15 @@ atmel_ice.protocol=atmelice_isp
 atmel_ice.program.protocol=atmelice_isp
 atmel_ice.program.tool=avrdude
 atmel_ice.program.extra_params=-Pusb
+
+avrdopercdc.name=AVR-Doper (CDC Mode)
+avrdopercdc.communication=serial
+avrdopercdc.protocol=stk500v2
+avrdopercdc.program.tool=avrdude
+avrdopercdc.program.extra_params=-P{serial.port}
+
+avrdoperhid.name=AVR-Doper (HID Mode)
+avrdoperhid.communication=usb
+avrdoperhid.protocol=stk500v2
+avrdoperhid.program.tool=avrdude
+avrdoperhid.program.extra_params=-Pavrdoper


### PR DESCRIPTION
AVR-Doper is an STK500v2 compatible programmer. See https://www.obdev.at/products/vusb/avrdoper.html for details.

It supports two modes of operation: CDC-mode and HID-mode. In the first mode, it provides a virtual serial port and works as an STK-500v2 compatible programmer connected to the virtual serial port. This mode is intended to be used with software which supports the STK500v2 programmer (including the Atmel Studio). On Windows, this mode requires a special driver installation (http://www.recursion.jp/prose/avrcdc/download.html) which might be problematic on 64-bit versions of Windows because the driver is unsigned. On Linux, it appears as a serial device.

The second mode is supported by the "avrdude".

Most of the USBASP programmers can be converted into the AVR-Doper by flashing the compatible firmware.