### PR TITLE
Update platform specification URLs in configuration files

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1,4 +1,4 @@
-# See: http://code.google.com/p/arduino/wiki/Platforms
+# See: https://arduino.github.io/arduino-cli/latest/platform-specification/
 
 menu.cpu=Processor
 

--- a/platform.txt
+++ b/platform.txt
@@ -3,7 +3,7 @@
 # ------------------------------
 #
 # For more info:
-# https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5-3rd-party-Hardware-specification
+# https://arduino.github.io/arduino-cli/latest/platform-specification/
 
 name=Arduino AVR Boards
 version=1.8.3


### PR DESCRIPTION
The Google Code URL that was in boards.txt is very outdated.

The URL that was in platform.txt is to a more recent home of the content, which has been replaced with a link to the new location, but while I'm updating boards.txt, I might as well point both URLs to [the real page](https://arduino.github.io/arduino-cli/latest/platform-specification/).