### PR TITLE
Add padStart and padEnd

### DIFF
--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -748,3 +748,25 @@ double String::toDouble(void) const
 	if (buffer) return atof(buffer);
 	return 0;
 }
+
+/*********************************************/
+/*  Padding                                  */
+/*********************************************/
+
+String String::padStart(unsigned int totalLength, const char pad)
+{
+	String str = this->c_str();
+	while (str.length() < totalLength) {
+		str = pad + str;
+	}
+	return str;
+}
+
+String String::padEnd(unsigned int totalLength, const char pad)
+{
+	String str = this->c_str();
+	while (str.length() < totalLength) {
+		str += pad;
+	}
+	return str;
+}

--- a/cores/arduino/WString.h
+++ b/cores/arduino/WString.h
@@ -192,6 +192,10 @@ public:
 	float toFloat(void) const;
 	double toDouble(void) const;
 
+	// padding
+	String padStart(unsigned int totalLength, const char pad = ' ');
+	String padEnd(unsigned int totalLength, const char pad = ' ');
+
 protected:
 	char *buffer;	        // the actual char array
 	unsigned int capacity;  // the array length minus one (for the '\0')


### PR DESCRIPTION
I want to use padding method on Arduino like javascript.
Could you consider adding these methods?

References
- [String.prototype.padStart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart)
- [String.prototype.padEnd](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd)

By the way, Arduino framework supports `depends` option so is there any plan to separate `String` as a library?

Thank you.