### PR TITLE
Finish USBDevice.detach() placeholder.

### DIFF
--- a/cores/arduino/USBAPI.h
+++ b/cores/arduino/USBAPI.h
@@ -62,6 +62,7 @@ public:
 	bool configured();
 
 	void attach();
+	// IDE CANNOT UPLOAD OVER USB WHILE DETACHED
 	void detach();	// Serial port goes down too...
 	void poll();
 	bool wakeupHost(); // returns false, when wakeup cannot be processed

--- a/cores/arduino/USBCore.cpp
+++ b/cores/arduino/USBCore.cpp
@@ -727,13 +727,13 @@ static inline void USB_ClockEnable()
 
 #if defined(RSTCPU)
 #if defined(LSM)
-	UDCON &= ~((1<<RSTCPU) | (1<<LSM) | (1<<RMWKUP) | (1<<DETACH));	// enable attach resistor, set full speed mode
+	UDCON &= ~((1<<RSTCPU) | (1<<LSM) | (1<<RMWKUP));	// set full speed mode
 #else // u2 Series
-	UDCON &= ~((1 << RSTCPU) | (1 << RMWKUP) | (1 << DETACH));	// enable attach resistor, set full speed mode
+	UDCON &= ~((1<<RSTCPU) | (1<<RMWKUP));	// set full speed mode
 #endif
 #else
 	// AT90USB64x and AT90USB128x don't have RSTCPU
-	UDCON &= ~((1<<LSM) | (1<<RMWKUP) | (1<<DETACH));	// enable attach resistor, set full speed mode
+	UDCON &= ~((1<<LSM) | (1<<RMWKUP));	// set full speed mode
 #endif
 }
 
@@ -813,14 +813,17 @@ void USBDevice_::attach()
 	_usbSuspendState = 0;
 	USB_ClockEnable();
 
+	UDCON &= ~(1<<DETACH); // attach USB pullup resistor
 	UDINT &= ~((1<<WAKEUPI) | (1<<SUSPI)); // clear already pending WAKEUP / SUSPEND requests
 	UDIEN = (1<<EORSTE) | (1<<SOFE) | (1<<SUSPE);	// Enable interrupts for EOR (End of Reset), SOF (start of frame) and SUSPEND
 	
 	TX_RX_LED_INIT;
 }
 
+// IDE CANNOT UPLOAD OVER USB WHILE DETACHED
 void USBDevice_::detach()
 {
+	UDCON |= (1<<DETACH); // detach USB pullup resistor
 }
 
 //	Check for interrupts


### PR DESCRIPTION
Only have Arduino Micro board to test on.

The ide fails to make the attempt to upload a sketch if the COM port is unavailable after detaching the USB serial CDC endpoint.

The RunnerException error in SerialUploader.java:152 should be caught and handled when attempting to upload to a nonexistent COM port. A console output should be given instructing the user to press the reset button, power cycle, or plug the board into a USB port so that the bootloader can upload a sketch from the IDE. This would allow a developer to upload sketches even when the sketch disables USB, or takes full control of the keyboard or mouse preventing the user from using their computer.

For example; if USBDevice.detach() is called in setup() a user would need to instruct avrdude on the command line and then get the device into the bootloader to upload a sketch. In practice the CDC endpoint resets the device and the IDE waits for the bootloader to upload the code. The bootloader can be physically triggered and a sketch uploaded if the IDE ignores the error when attempting to open the serial port and send the reset signal.