### PR TITLE
Make EEPROM variable 'extern'

### DIFF
--- a/libraries/EEPROM/src/EEPROM.cpp
+++ b/libraries/EEPROM/src/EEPROM.cpp
@@ -1,0 +1,4 @@
+#include "EEPROM.h"
+
+EEPROMClass EEPROM;
+

--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -142,5 +142,5 @@ struct EEPROMClass{
     }
 };
 
-static EEPROMClass EEPROM;
+extern EEPROMClass EEPROM;
 #endif


### PR DESCRIPTION
Fixes https://github.com/arduino/ArduinoCore-avr/issues/399, a compiler warning in any compilation unit where EEPROM.h is directly or indirectly included by not used.