### PR TITLE
Added support with 3v3 Devices and provision safe future reset by timeout

### DIFF
--- a/libraries/Wire/keywords.txt
+++ b/libraries/Wire/keywords.txt
@@ -17,6 +17,7 @@ endTransmission	KEYWORD2
 requestFrom	KEYWORD2
 onReceive	KEYWORD2
 onRequest	KEYWORD2
+disablePullups KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)

--- a/libraries/Wire/library.properties
+++ b/libraries/Wire/library.properties
@@ -1,5 +1,5 @@
 name=Wire
-version=1.0
+version=1.1
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=This library allows you to communicate with I2C and Two Wire Interface devices.

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -19,6 +19,7 @@
   Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
   Modified 2017 by Chuck Todd (ctodd@cableone.net) to correct Unconfigured Slave Mode reboot
   Modified 2020 by Greyson Christoforo (grey@christoforo.net) to implement timeouts
+  Modified 2021 by Fernando Rubio (frubio@techdev.cl) to support I2C 3v3 devices
 */
 
 extern "C" {
@@ -80,6 +81,11 @@ void TwoWire::begin(int address)
 void TwoWire::end(void)
 {
   twi_disable();
+}
+
+void TwoWire::disablePullups(void)
+{
+  twi_disablePullups();
 }
 
 void TwoWire::setClock(uint32_t clock)

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -18,6 +18,7 @@
 
   Modified 2012 by Todd Krein (todd@krein.org) to implement repeated starts
   Modified 2020 by Greyson Christoforo (grey@christoforo.net) to implement timeouts
+  Modified 2021 by Fernando Rubio (frubio@techdev.cl) to support I2C 3v3 devices
 */
 
 #ifndef TwoWire_h
@@ -54,6 +55,7 @@ class TwoWire : public Stream
     void begin(uint8_t);
     void begin(int);
     void end();
+    void disablePullups();
     void setClock(uint32_t);
     void setWireTimeout(uint32_t timeout = 25000, bool reset_with_timeout = false);
     bool getWireTimeoutFlag(void);

--- a/libraries/Wire/src/utility/twi.h
+++ b/libraries/Wire/src/utility/twi.h
@@ -17,6 +17,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
   Modified 2020 by Greyson Christoforo (grey@christoforo.net) to implement timeouts
+  Modified 2021 by Fernando Rubio (frubio@techdev.cl) to support I2C 3v3 devices
 */
 
 #ifndef twi_h
@@ -42,6 +43,7 @@
   
   void twi_init(void);
   void twi_disable(void);
+  void twi_disablePullups(void);
   void twi_setAddress(uint8_t);
   void twi_setFrequency(uint32_t);
   uint8_t twi_readFrom(uint8_t, uint8_t*, uint8_t, uint8_t);


### PR DESCRIPTION
Added support with 3v3 devices, allowing to disable internal pull-ups.
Added the twi_pullups_state, default to enabled (1) for backward compatibility. This state is necessary to preserve the desired pullups state on each call to begin() and twi_init(), in future resets by timeouts.