### PR TITLE
Add a weak wrapper for SoftwareSerial::handle_interrupt

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -225,22 +225,51 @@ inline void SoftwareSerial::handle_interrupt()
 }
 
 #if defined(PCINT0_vect)
-ISR(PCINT0_vect)
+void pcint0_isr_wrapper()
 {
   SoftwareSerial::handle_interrupt();
+}
+
+ISR(PCINT0_vect)
+{
+  pcint0_isr_wrapper();
 }
 #endif
 
 #if defined(PCINT1_vect)
-ISR(PCINT1_vect, ISR_ALIASOF(PCINT0_vect));
+void pcint1_isr_wrapper()
+{
+  SoftwareSerial::handle_interrupt();
+}
+
+ISR(PCINT1_vect)
+{
+  pcint1_isr_wrapper();
+}
 #endif
 
 #if defined(PCINT2_vect)
-ISR(PCINT2_vect, ISR_ALIASOF(PCINT0_vect));
+void pcint2_isr_wrapper()
+{
+  SoftwareSerial::handle_interrupt();
+}
+
+ISR(PCINT2_vect)
+{
+  pcint2_isr_wrapper();
+}
 #endif
 
 #if defined(PCINT3_vect)
-ISR(PCINT3_vect, ISR_ALIASOF(PCINT0_vect));
+void pcint3_isr_wrapper()
+{
+  SoftwareSerial::handle_interrupt();
+}
+
+ISR(PCINT3_vect)
+{
+  pcint3_isr_wrapper();
+}
 #endif
 
 //

--- a/libraries/SoftwareSerial/src/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.h
@@ -107,8 +107,20 @@ public:
   
   using Print::write;
 
-  // public only for easy access by interrupt handlers
-  static inline void handle_interrupt() __attribute__((__always_inline__));
+  static void handle_interrupt();
 };
+
+#if defined(PCINT0_vect)
+void pcint0_isr_wrapper() __attribute__ ((weak));
+#endif
+#if defined(PCINT1_vect)
+void pcint1_isr_wrapper() __attribute__ ((weak));
+#endif
+#if defined(PCINT2_vect)
+void pcint2_isr_wrapper() __attribute__ ((weak));
+#endif
+#if defined(PCINT3_vect)
+void pcint3_isr_wrapper() __attribute__ ((weak));
+#endif
 
 #endif


### PR DESCRIPTION
This makes it easier to use this library in applications that also use PCINTx for other purposes.