### PR TITLE
Revert "Declare TwoWire functions as virtual"

### DIFF
--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -50,31 +50,31 @@ class TwoWire : public Stream
     static void onReceiveService(uint8_t*, int);
   public:
     TwoWire();
-    virtual void begin();
-    virtual void begin(uint8_t);
-    virtual void begin(int);
-    virtual void end();
-    virtual void setClock(uint32_t);
-    virtual void setWireTimeout(uint32_t timeout = 25000, bool reset_with_timeout = false);
-    virtual bool getWireTimeoutFlag(void);
-    virtual void clearWireTimeoutFlag(void);
-    virtual void beginTransmission(uint8_t);
-    virtual void beginTransmission(int);
-    virtual uint8_t endTransmission(void);
-    virtual uint8_t endTransmission(uint8_t);
-    virtual uint8_t requestFrom(uint8_t, uint8_t);
-    virtual uint8_t requestFrom(uint8_t, uint8_t, uint8_t);
-    virtual uint8_t requestFrom(uint8_t, uint8_t, uint32_t, uint8_t, uint8_t);
-    virtual uint8_t requestFrom(int, int);
-    virtual uint8_t requestFrom(int, int, int);
+    void begin();
+    void begin(uint8_t);
+    void begin(int);
+    void end();
+    void setClock(uint32_t);
+    void setWireTimeout(uint32_t timeout = 25000, bool reset_with_timeout = false);
+    bool getWireTimeoutFlag(void);
+    void clearWireTimeoutFlag(void);
+    void beginTransmission(uint8_t);
+    void beginTransmission(int);
+    uint8_t endTransmission(void);
+    uint8_t endTransmission(uint8_t);
+    uint8_t requestFrom(uint8_t, uint8_t);
+    uint8_t requestFrom(uint8_t, uint8_t, uint8_t);
+    uint8_t requestFrom(uint8_t, uint8_t, uint32_t, uint8_t, uint8_t);
+    uint8_t requestFrom(int, int);
+    uint8_t requestFrom(int, int, int);
     virtual size_t write(uint8_t);
     virtual size_t write(const uint8_t *, size_t);
     virtual int available(void);
     virtual int read(void);
     virtual int peek(void);
     virtual void flush(void);
-    virtual void onReceive( void (*)(int) );
-    virtual void onRequest( void (*)(void) );
+    void onReceive( void (*)(int) );
+    void onRequest( void (*)(void) );
 
     inline size_t write(unsigned long n) { return write((uint8_t)n); }
     inline size_t write(long n) { return write((uint8_t)n); }


### PR DESCRIPTION
Reverts arduino/ArduinoCore-avr#396

PR was found consuming too much ressources, see [here](https://github.com/arduino/ArduinoCore-avr/pull/396#issuecomment-848204777).