### PR TITLE
Update Arduino.h: no signature uses typedef byte, uint8_t is used everywhere

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -237,7 +237,7 @@ extern const uint8_t PROGMEM digital_pin_to_timer_PGM[];
 #endif
 
 uint16_t makeWord(uint16_t w);
-uint16_t makeWord(byte h, byte l);
+uint16_t makeWord(uint8_t h, uint8_t l);
 
 #define word(...) makeWord(__VA_ARGS__)
 

--- a/cores/arduino/WMath.cpp
+++ b/cores/arduino/WMath.cpp
@@ -22,7 +22,8 @@
 */
 
 extern "C" {
-  #include "stdlib.h"
+  #include <stdlib.h>
+  #include <inttypes.h>
 }
 
 void randomSeed(unsigned long seed)

--- a/cores/arduino/WMath.cpp
+++ b/cores/arduino/WMath.cpp
@@ -54,5 +54,5 @@ long map(long x, long in_min, long in_max, long out_min, long out_max)
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
 
-unsigned int makeWord(unsigned int w) { return w; }
-unsigned int makeWord(unsigned char h, unsigned char l) { return (h << 8) | l; }
+uint16_t makeWord(uint16_t w) { return w; }
+uint16_t makeWord(uint8_t h, uint8_t l) { return (h << 8) | l; }


### PR DESCRIPTION
Typedef byte is never used except in makeword, align with that.