### PR TITLE
Don't use codespell's "rare" dictionary for CI spell check

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -2,6 +2,7 @@
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
 ignore-words-list = hart,pullrequest
+builtin = clear
 check-filenames =
 check-hidden =
 skip = ./.git,./firmwares/arduinoISP,./firmwares/wifishield,./bootloaders


### PR DESCRIPTION
The word "statics" was recently added to codespell's "rare" commonly misspelled words directory. By default, this
dictionary is used in addition to the more conservative "clear" dictionary, resulting in a spurious failure of the
"Spell Check" CI workflow.

Although this could be fixed by adding the word to the ignore list, it seems that an increasing number of common words
being added to this dictionary, so I think it's best to just remove it altogether. The goal for the "Spell Check"
workflow is to catch some typos without a significant number of false positives, even if that means some misspellings
slip through. I think the "clear" dictionary is more in line with that goal.