### PR TITLE
HID bugfix: SET_IDLE uses wValueH for duration, not wValueL

### DIFF
--- a/libraries/HID/src/HID.cpp
+++ b/libraries/HID/src/HID.cpp
@@ -128,7 +128,7 @@ bool HID_::setup(USBSetup& setup)
 			return true;
 		}
 		if (request == HID_SET_IDLE) {
-			idle = setup.wValueL;
+			idle = setup.wValueH;
 			return true;
 		}
 		if (request == HID_SET_REPORT)


### PR DESCRIPTION
The duration in the SET_IDLE request is actually responsible for the highest byte, not the lowest. Here is an excerpt from the standard:
![image](https://user-images.githubusercontent.com/416259/126744507-613ab8c2-c613-42ea-9550-a41e4ab665f9.png)

![image](https://user-images.githubusercontent.com/416259/126744512-6e174032-6f7b-4f54-bedd-a2591604524d.png)

To verify this, I used [USBCV](https://www.usb.org/document-library/usb3cvx64-tool), the official tool for testing compliance with USB standards. Without this patch, the "Idle Test" was a failure, everything works as it should with the patch.), the official tool for testing compliance with USB standards. Without this patch, the "Idle Test" was a failure, everything works as it should with the patch.