### PR TITLE
Add FPSTR() macro to WString.h

### DIFF
--- a/cores/arduino/WString.h
+++ b/cores/arduino/WString.h
@@ -35,7 +35,8 @@
 //     -std=c++0x
 
 class __FlashStringHelper;
-#define F(string_literal) (reinterpret_cast<const __FlashStringHelper *>(PSTR(string_literal)))
+#define FPSTR(pstr_pointer) (reinterpret_cast<const __FlashStringHelper *>(pstr_pointer))
+#define F(string_literal) (FPSTR(PSTR(string_literal)))
 
 // An inherited class for holding the result of a concatenation.  These
 // result objects are assumed to be writable by subsequent concatenations.


### PR DESCRIPTION
This Pull Request adds the `FPSTR()` macro to WString.h.
The purpose of this Macro is to allow you to pass a previously defined string with the PROGMEM attribute - without having to define it inline (as you do with the `F()` macro).
The `F()` macro is also redefined, to make use of the `FPSTR()` macro.

The macro implementation was taken from [WString.h in the esp8266 Arduino core](https://github.com/esp8266/Arduino/blob/master/cores/esp8266/WString.h#L39) - which is also GPL licensed.

The esp8266 [PROGMEM](https://github.com/esp8266/Arduino/blob/master/doc/PROGMEM.rst) documentation states:
> 
> So `FPSTR()` takes a PROGMEM pointer to a string and casts it to this
> `__FlashStringHelper` class. Thus if you have defined a string as
> above `xyz` you can use `FPSTR()` to convert it to
> `__FlashStringHelper` for passing into functions that take it.
> 
> ```c
> static const char xyz[] PROGMEM = "This is a string stored in flash";
> Serial.println(FPSTR(xyz));
> ```

My interest in this Macro is for the [EtherCard](https://github.com/njh/EtherCard) library to assist with putting the MAC address in programme memory, instead of RAM. I did some tests in this Sketch:
https://gist.github.com/njh/de1cec7c883bcfe35df3956340fa30ab

