### PR TITLE
Speed up 'available' method by inserting unsigned int cast

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -409,7 +409,7 @@ int SoftwareSerial::available()
   if (!isListening())
     return 0;
 
-  return (_receive_buffer_tail + _SS_MAX_RX_BUFF - _receive_buffer_head) % _SS_MAX_RX_BUFF;
+  return ((unsigned int)(_receive_buffer_tail + _SS_MAX_RX_BUFF - _receive_buffer_head)) % _SS_MAX_RX_BUFF;
 }
 
 size_t SoftwareSerial::write(uint8_t b)


### PR DESCRIPTION
This speeds up the _available_ method in the **SoftwareSerial** library by a factor of 10!

Without the cast, the compiler generates the following code (the value of the left operand is already in r24:r25):
 ldi	r22, 0x40	; 64
 ldi	r23, 0x00	; 0
 call	0xdae	; 0xdae <__divmodhi4>
 In other words, by calling the software div/mod routine, a call to the _available_ method takes more than 15 µs! 

With the cast (which by the way the HardwareSerial class also uses), the generated code looks as follows:
 andi r24, 0x3F	; 63
 eor	r25, r25
 With that, a call to the method uses roughly 1.5 µs.