### PR TITLE
.github/workflows/compile-platform-examples: Correct YAML files extension.

### DIFF
--- a/.github/workflows/compile-platform-examples.yml
+++ b/.github/workflows/compile-platform-examples.yml
@@ -4,7 +4,7 @@ name: Compile Examples
 on:
   push:
     paths:
-      - ".github/workflows/compile-platform-examples.ya?ml"
+      - ".github/workflows/compile-platform-examples.yml"
       - "cores/**"
       - "libraries/**"
       - "variants/**"
@@ -12,7 +12,7 @@ on:
       - "platform.txt"
   pull_request:
     paths:
-      - ".github/workflows/compile-platform-examples.ya?ml"
+      - ".github/workflows/compile-platform-examples.yml"
       - "cores/**"
       - "libraries/**"
       - "variants/**"


### PR DESCRIPTION
There is a typo in the extension of the YML file, `ya?ml` instead of `yml` or `yaml`.