### PR TITLE
Add unomini to sketch compilation CI workflow

### DIFF
--- a/.github/workflows/compile-platform-examples.yml
+++ b/.github/workflows/compile-platform-examples.yml
@@ -145,6 +145,9 @@ jobs:
           - fqbn: arduino:avr:unowifi
             serial: true
             softwareserial: true
+          - fqbn: arduino:avr:unomini
+            serial: true
+            softwareserial: true
 
         # Make board type-specific customizations to the matrix jobs
         include:


### PR DESCRIPTION
The "Compile Examples" GitHub Actions workflow provides a basic "smoke test" for the platform by compiling the relevant example sketches for each of the boards on every commit and pull request.

A new board has been added to the platform ([Uno Mini](https://store.arduino.cc/products/uno-mini-le)) and so should be added to the list of boards compiled for in this workflow.

Even though the Uno compilation does provide reasonable coverage for the Uno Mini due to their similar configurations, that coverage does not extend to [the board definition](https://github.com/arduino/ArduinoCore-avr/blob/1.8.4/boards.txt#L1277-L1306) itself.