### PR TITLE
Use more logical Boards menu placement for Uno Mini

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -103,6 +103,39 @@ uno.build.variant=standard
 
 ##############################################################
 
+unomini.name=Arduino Uno Mini
+
+unomini.vid.0=0x2341
+unomini.pid.0=0x0062
+unomini.upload_port.0.vid=0x2341
+unomini.upload_port.0.pid=0x0062
+unomini.upload_port.4.board=unomini
+
+unomini.upload.tool=avrdude
+unomini.upload.tool.default=avrdude
+unomini.upload.tool.network=arduino_ota
+unomini.upload.protocol=arduino
+unomini.upload.maximum_size=32256
+unomini.upload.maximum_data_size=2048
+unomini.upload.speed=115200
+
+unomini.bootloader.tool=avrdude
+unomini.bootloader.tool.default=avrdude
+unomini.bootloader.low_fuses=0xFF
+unomini.bootloader.high_fuses=0xDE
+unomini.bootloader.extended_fuses=0xFD
+unomini.bootloader.unlock_bits=0x3F
+unomini.bootloader.lock_bits=0x0F
+unomini.bootloader.file=optiboot/optiboot_atmega328.hex
+
+unomini.build.mcu=atmega328p
+unomini.build.f_cpu=16000000L
+unomini.build.board=AVR_UNO
+unomini.build.core=arduino
+unomini.build.variant=standard
+
+##############################################################
+
 diecimila.name=Arduino Duemilanove or Diecimila
 
 diecimila.upload_port.0.board=diecimila
@@ -1271,38 +1304,5 @@ unowifi.build.core=arduino
 unowifi.build.variant=standard
 unowifi.build.esp_ch_uart_br=19200
 unowifi.build.extra_flags=-DESP_CH_UART -DESP_CH_UART_BR={build.esp_ch_uart_br}
-
-##############################################################
-
-unomini.name=Arduino Uno Mini
-
-unomini.vid.0=0x2341
-unomini.pid.0=0x0062
-unomini.upload_port.0.vid=0x2341
-unomini.upload_port.0.pid=0x0062
-unomini.upload_port.4.board=unomini
-
-unomini.upload.tool=avrdude
-unomini.upload.tool.default=avrdude
-unomini.upload.tool.network=arduino_ota
-unomini.upload.protocol=arduino
-unomini.upload.maximum_size=32256
-unomini.upload.maximum_data_size=2048
-unomini.upload.speed=115200
-
-unomini.bootloader.tool=avrdude
-unomini.bootloader.tool.default=avrdude
-unomini.bootloader.low_fuses=0xFF
-unomini.bootloader.high_fuses=0xDE
-unomini.bootloader.extended_fuses=0xFD
-unomini.bootloader.unlock_bits=0x3F
-unomini.bootloader.lock_bits=0x0F
-unomini.bootloader.file=optiboot/optiboot_atmega328.hex
-
-unomini.build.mcu=atmega328p
-unomini.build.f_cpu=16000000L
-unomini.build.board=AVR_UNO
-unomini.build.core=arduino
-unomini.build.variant=standard
 
 ##############################################################


### PR DESCRIPTION
Arduino has added a new board to the AVR-based line: [the Uno Mini](https://store.arduino.cc/products/uno-mini-le). The Uno Mini has its own board definition in this platform, which produces a dedicated item in the **Tools > Board** menu of the Arduino IDE.

The classic Arduino IDE arranges the Boards menu for each platform according to the order of occurrence of the board definition in the platform's [`boards.txt` configuration file](https://arduino.github.io/arduino-cli/dev/platform-specification/#boardstxt). The previous placement of the Uno Mini board definition resulted in the board appearing at the end of the menu, along with retired and 3rd party boards:

![image](https://user-images.githubusercontent.com/8572152/147853707-ae59247a-1093-400f-bc55-1c2d35d5d81d.png)

The placement proposed in this PR will cause it to be shown alongside the related [Arduino Uno](https://store.arduino.cc/products/arduino-uno-rev3) and in a position befitting the latest
official AVR board:

![image](https://user-images.githubusercontent.com/8572152/147853713-1eb9a8dd-927e-4829-9be2-ba16a3db6c47.png)