### PR TITLE
Mark unused parameters with [[gnu::unused]]

### DIFF
--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -56,7 +56,7 @@ void * operator new[](std::size_t size) {
   return operator new(size);
 }
 
-void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
+void * operator new(std::size_t size, [[gnu::unused]] const std::nothrow_t tag) noexcept {
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new as standard suggests, so call
   // new_helper directly then
@@ -65,7 +65,7 @@ void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
   return operator new(size);
 #endif
 }
-void * operator new[](std::size_t size, const std::nothrow_t& tag) noexcept {
+void * operator new[](std::size_t size, [[gnu::unused]] const std::nothrow_t& tag) noexcept {
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new[] as standard suggests, so call
   // malloc directly then
@@ -100,10 +100,10 @@ void operator delete[](void * ptr, std::size_t size) noexcept {
 }
 #endif // __cplusplus >= 201402L
 
-void operator delete(void* ptr, const std::nothrow_t& tag) noexcept {
+void operator delete(void* ptr, [[gnu::unused]] const std::nothrow_t& tag) noexcept {
   operator delete(ptr);
 }
-void operator delete[](void* ptr, const std::nothrow_t& tag) noexcept {
+void operator delete[](void* ptr, [[gnu::unused]] const std::nothrow_t& tag) noexcept {
   operator delete[](ptr);
 }
 


### PR DESCRIPTION
As of version 1.8.4, when compiling with warning level "all" in the IDE and arduino-cli, there are warnings about unused parameters in the implementation of operator new ([cores/arduino/new.cpp](https://github.com/arduino/ArduinoCore-avr/blob/1.8.4/cores/arduino/new.cpp)).

This PR marks these parameters with `[[gnu::unused]]`.

Fixes https://github.com/arduino/ArduinoCore-avr/issues/508