### PR TITLE
Move definition of INADDR_NONE to IPAddress.cpp

### DIFF
--- a/cores/arduino/IPAddress.cpp
+++ b/cores/arduino/IPAddress.cpp
@@ -112,3 +112,4 @@ size_t IPAddress::printTo(Print& p) const
     return n;
 }
 
+const IPAddress INADDR_NONE(0,0,0,0);

--- a/cores/arduino/IPAddress.h
+++ b/cores/arduino/IPAddress.h
@@ -73,6 +73,6 @@ public:
     friend class DNSClient;
 };
 
-const IPAddress INADDR_NONE(0,0,0,0);
+extern const IPAddress INADDR_NONE;
 
 #endif


### PR DESCRIPTION
This was a fix implemented in https://github.com/arduino/ArduinoCore-avr/pull/329 but the branch is currently awaiting changes. This is, however, just the one change.