### PR TITLE
Prevent multiples calls to TwoWire::begin()

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -55,6 +55,8 @@ TwoWire::TwoWire()
 
 void TwoWire::begin(void)
 {
+  if (began) return;
+
   rxBufferIndex = 0;
   rxBufferLength = 0;
 

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -34,6 +34,8 @@
 class TwoWire : public Stream
 {
   private:
+    bool began = false;
+
     static uint8_t rxBuffer[];
     static uint8_t rxBufferIndex;
     static uint8_t rxBufferLength;


### PR DESCRIPTION
Calling TwoWire::begin() multiples times can lead to some of the sneakiest bugs. This can happen when multiple third-party libraries call Wire.begin(). This fix aims to prevent that.