### PR TITLE
Prevent 'unused parameter' Warnings

### DIFF
--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -57,6 +57,8 @@ void * operator new[](std::size_t size) {
 }
 
 void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
+  // Prevent an 'unused parameter' warning
+  static_cast<void>(tag);
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new as standard suggests, so call
   // new_helper directly then
@@ -66,6 +68,8 @@ void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
 #endif
 }
 void * operator new[](std::size_t size, const std::nothrow_t& tag) noexcept {
+  // Prevent an 'unused parameter' warning
+  static_cast<void>(tag);
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new[] as standard suggests, so call
   // malloc directly then
@@ -101,9 +105,13 @@ void operator delete[](void * ptr, std::size_t size) noexcept {
 #endif // __cplusplus >= 201402L
 
 void operator delete(void* ptr, const std::nothrow_t& tag) noexcept {
+  // Prevent an 'unused parameter' warning
+  static_cast<void>(tag);
   operator delete(ptr);
 }
 void operator delete[](void* ptr, const std::nothrow_t& tag) noexcept {
+  // Prevent an 'unused parameter' warning
+  static_cast<void>(tag);
   operator delete[](ptr);
 }
 


### PR DESCRIPTION
At the moment the compiler keeps complaining about the `tag` parameters being unused.
(`warning: unused parameter 'tag' [-Wunused-parameter]`)

This fixes that by using a `static_cast<void>` to make the compiler aware that they aren't supposed to be used.

(Another alternative would have been to remove the parameter name.)