### PR TITLE
SoftwareSerial: Add support for half-duplex

### DIFF
--- a/libraries/SoftwareSerial/src/SoftwareSerial.cpp
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.cpp
@@ -439,7 +439,7 @@ int SoftwareSerial::available()
 size_t SoftwareSerial::write(uint8_t b)
 {
   if (_singleWirePin && isListening())
-    setupTXPin();
+    setupTXPin(_singleWirePin);
 
   if (_tx_delay == 0) {
     setWriteError();

--- a/libraries/SoftwareSerial/src/SoftwareSerial.h
+++ b/libraries/SoftwareSerial/src/SoftwareSerial.h
@@ -51,6 +51,7 @@ class SoftwareSerial : public Stream
 {
 private:
   // per object data
+  uint8_t _singleWirePin;
   uint8_t _receivePin;
   uint8_t _receiveBitMask;
   volatile uint8_t *_receivePortRegister;
@@ -79,6 +80,8 @@ private:
   uint8_t rx_pin_read();
   void setTX(uint8_t transmitPin);
   void setRX(uint8_t receivePin);
+  void setupTXPin(uint8_t transmitPin);
+  void setupRXPin(uint8_t receivePin);
   inline void setRxIntMsk(bool enable) __attribute__((__always_inline__));
 
   // Return num - sub, or 1 if the result would be < 1


### PR DESCRIPTION
resolves #205

This pull request allows using the same pin for RX/TX in half-duplex mode. By using `listen` and `stopListening` one can switch between reading and writing. Calling `write` while listening will instantly return 0 (currently without setting a write error).
 
I tested bidirectional communication using a Mega2560 and an Uno connected via a single wire.