### PR TITLE
ESP core `printf` implementation in AVR core.

### DIFF
--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -264,3 +264,33 @@ size_t Print::printFloat(double number, uint8_t digits)
   
   return n;
 }
+
+size_t Print::printf(const char *format, ...)
+{
+    char loc_buf[64];
+    char * temp = loc_buf;
+    va_list arg;
+    va_list copy;
+    va_start(arg, format);
+    va_copy(copy, arg);
+    int len = vsnprintf(temp, sizeof(loc_buf), format, copy);
+    va_end(copy);
+    if(len < 0) {
+        va_end(arg);
+        return 0;
+    };
+    if(len >= sizeof(loc_buf)){
+        temp = (char*) malloc(len+1);
+        if(temp == NULL) {
+            va_end(arg);
+            return 0;
+        }
+        len = vsnprintf(temp, len+1, format, arg);
+    }
+    va_end(arg);
+    len = write((uint8_t*)temp, len);
+    if(temp != loc_buf){
+        free(temp);
+    }
+    return len;
+}

--- a/cores/arduino/Print.h
+++ b/cores/arduino/Print.h
@@ -74,6 +74,8 @@ class Print
     size_t print(double, int = 2);
     size_t print(const Printable&);
 
+    size_t printf(const char * format, ...)  __attribute__ ((format (printf, 2, 3)));
+
     size_t println(const __FlashStringHelper *);
     size_t println(const String &s);
     size_t println(const char[]);


### PR DESCRIPTION
This addition will allow for convenient printing using the `printf` function, as implemented in the ESP core.

**Example**

Consider the following block of code.
```cpp
Serial.print("(");
Serial.print(i);
Serial.print(", ");
Serial.print(j);
Serial.print("): ");
Serial.println(result);
```

This can be replaced by the following line.

```cpp
Serial.printf("(%i, %i): %i\r\n", i, j, result);
```

I hope you find this useful.