### PR TITLE
Removed a number of compiler warnings.

### DIFF
--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -267,30 +267,30 @@ size_t Print::printFloat(double number, uint8_t digits)
 
 size_t Print::printf(const char *format, ...)
 {
-    char loc_buf[64];
-    char * temp = loc_buf;
-    va_list arg;
-    va_list copy;
-    va_start(arg, format);
-    va_copy(copy, arg);
-    int len = vsnprintf(temp, sizeof(loc_buf), format, copy);
-    va_end(copy);
-    if(len < 0) {
-        va_end(arg);
-        return 0;
-    };
-    if(len >= sizeof(loc_buf)){
-        temp = (char*) malloc(len+1);
-        if(temp == NULL) {
-            va_end(arg);
-            return 0;
-        }
-        len = vsnprintf(temp, len+1, format, arg);
-    }
+  char loc_buf[64];
+  char* temp = loc_buf;
+  va_list arg;
+  va_list copy;
+  va_start(arg, format);
+  va_copy(copy, arg);
+  int len = vsnprintf(temp, sizeof(loc_buf), format, copy);
+  va_end(copy);
+  if (len < 0) {
     va_end(arg);
-    len = write((uint8_t*)temp, len);
-    if(temp != loc_buf){
-        free(temp);
+    return 0;
+  }
+  if (len >= (int)sizeof(loc_buf)) {
+    temp = (char*)malloc(len + 1);
+    if (temp == NULL) {
+      va_end(arg);
+      return 0;
     }
-    return len;
+    len = vsnprintf(temp, len + 1, format, arg);
+  }
+  va_end(arg);
+  len = write((uint8_t*)temp, len);
+  if (temp != loc_buf) {
+    free(temp);
+  }
+  return len;
 }

--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -264,3 +264,33 @@ size_t Print::printFloat(double number, uint8_t digits)
   
   return n;
 }
+
+size_t Print::printf(const char *format, ...)
+{
+    char loc_buf[64];
+    char * temp = loc_buf;
+    va_list arg;
+    va_list copy;
+    va_start(arg, format);
+    va_copy(copy, arg);
+    int len = vsnprintf(temp, sizeof(loc_buf), format, copy);
+    va_end(copy);
+    if(len < 0) {
+        va_end(arg);
+        return 0;
+    };
+    if(len >= sizeof(loc_buf)){
+        temp = (char*) malloc(len+1);
+        if(temp == NULL) {
+            va_end(arg);
+            return 0;
+        }
+        len = vsnprintf(temp, len+1, format, arg);
+    }
+    va_end(arg);
+    len = write((uint8_t*)temp, len);
+    if(temp != loc_buf){
+        free(temp);
+    }
+    return len;
+}

--- a/cores/arduino/Print.h
+++ b/cores/arduino/Print.h
@@ -74,6 +74,8 @@ class Print
     size_t print(double, int = 2);
     size_t print(const Printable&);
 
+    size_t printf(const char * format, ...)  __attribute__ ((format (printf, 2, 3)));
+
     size_t println(const __FlashStringHelper *);
     size_t println(const String &s);
     size_t println(const char[]);

--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -56,7 +56,7 @@ void * operator new[](std::size_t size) {
   return operator new(size);
 }
 
-void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
+void * operator new(std::size_t size, const std::nothrow_t) noexcept {
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new as standard suggests, so call
   // new_helper directly then
@@ -65,7 +65,7 @@ void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
   return operator new(size);
 #endif
 }
-void * operator new[](std::size_t size, const std::nothrow_t& tag) noexcept {
+void * operator new[](std::size_t size, const std::nothrow_t&) noexcept {
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new[] as standard suggests, so call
   // malloc directly then
@@ -100,10 +100,10 @@ void operator delete[](void * ptr, std::size_t size) noexcept {
 }
 #endif // __cplusplus >= 201402L
 
-void operator delete(void* ptr, const std::nothrow_t& tag) noexcept {
+void operator delete(void* ptr, const std::nothrow_t&) noexcept {
   operator delete(ptr);
 }
-void operator delete[](void* ptr, const std::nothrow_t& tag) noexcept {
+void operator delete[](void* ptr, const std::nothrow_t&) noexcept {
   operator delete[](ptr);
 }
 


### PR DESCRIPTION
This "patch" will result in the suppression of a number of warnings that are the result of unused parameters. In particular the following warnings are removed.

```txt
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp: In function 'void* operator new(std::size_t, std::nothrow_t)':
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp:59:60: warning: unused parameter 'tag' [-Wunused-parameter]
 void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
                                                            ^~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp: In function 'void* operator new [](std::size_t, const std::nothrow_t&)':
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp:68:63: warning: unused parameter 'tag' [-Wunused-parameter]
 void * operator new[](std::size_t size, const std::nothrow_t& tag) noexcept {
                                                               ^~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp: In function 'void operator delete(void*, const std::nothrow_t&)':
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp:103:55: warning: unused parameter 'tag' [-Wunused-parameter]
 void operator delete(void* ptr, const std::nothrow_t& tag) noexcept {
                                                       ^~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp: In function 'void operator delete [](void*, const std::nothrow_t&)':
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp:106:57: warning: unused parameter 'tag' [-Wunused-parameter]
 void operator delete[](void* ptr, const std::nothrow_t& tag) noexcept {
                                                         ^~~
```

P.S. There are some more warnings about the use of binary constants (e.g., `0b11111000`). I can also take care of them if you like.