### PR TITLE
Removed compiler warnings (unused variable).

### DIFF
--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -56,7 +56,7 @@ void * operator new[](std::size_t size) {
   return operator new(size);
 }
 
-void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
+void * operator new(std::size_t size, const std::nothrow_t) noexcept {
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new as standard suggests, so call
   // new_helper directly then
@@ -65,7 +65,7 @@ void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
   return operator new(size);
 #endif
 }
-void * operator new[](std::size_t size, const std::nothrow_t& tag) noexcept {
+void * operator new[](std::size_t size, const std::nothrow_t&) noexcept {
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new[] as standard suggests, so call
   // malloc directly then
@@ -100,10 +100,10 @@ void operator delete[](void * ptr, std::size_t size) noexcept {
 }
 #endif // __cplusplus >= 201402L
 
-void operator delete(void* ptr, const std::nothrow_t& tag) noexcept {
+void operator delete(void* ptr, const std::nothrow_t&) noexcept {
   operator delete(ptr);
 }
-void operator delete[](void* ptr, const std::nothrow_t& tag) noexcept {
+void operator delete[](void* ptr, const std::nothrow_t&) noexcept {
   operator delete[](ptr);
 }
 


### PR DESCRIPTION
This "patch" will result in the suppression of a number of warnings that are the result of unused parameters. In particular the following warnings are removed.

```txt
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp: In function 'void* operator new(std::size_t, std::nothrow_t)':
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp:59:60: warning: unused parameter 'tag' [-Wunused-parameter]
 void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
                                                            ^~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp: In function 'void* operator new [](std::size_t, const std::nothrow_t&)':
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp:68:63: warning: unused parameter 'tag' [-Wunused-parameter]
 void * operator new[](std::size_t size, const std::nothrow_t& tag) noexcept {
                                                               ^~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp: In function 'void operator delete(void*, const std::nothrow_t&)':
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp:103:55: warning: unused parameter 'tag' [-Wunused-parameter]
 void operator delete(void* ptr, const std::nothrow_t& tag) noexcept {
                                                       ^~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp: In function 'void operator delete [](void*, const std::nothrow_t&)':
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/new.cpp:106:57: warning: unused parameter 'tag' [-Wunused-parameter]
 void operator delete[](void* ptr, const std::nothrow_t& tag) noexcept {
                                                         ^~~
```

P.S. There are some more warnings about the use of binary constants (e.g., `0b11111000`). I can also take care of them if you like.