### PR TITLE
Removed compiler warnings (binary constants).

### DIFF
--- a/cores/arduino/Tone.cpp
+++ b/cores/arduino/Tone.cpp
@@ -242,7 +242,7 @@ static int8_t toneBegin(uint8_t _pin)
 
 void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
 {
-  uint8_t prescalarbits = 0b001;
+  uint8_t prescalarbits = 0x01;
   long toggle_count = 0;
   uint32_t ocr = 0;
   int8_t _timer;
@@ -258,38 +258,38 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
     if (_timer == 0 || _timer == 2)
     {
       ocr = F_CPU / frequency / 2 - 1;
-      prescalarbits = 0b001;  // ck/1: same for both timers
+      prescalarbits = 0x01;  // ck/1: same for both timers
       if (ocr > 255)
       {
         ocr = F_CPU / frequency / 2 / 8 - 1;
-        prescalarbits = 0b010;  // ck/8: same for both timers
+        prescalarbits = 0x02;  // ck/8: same for both timers
 
         if (_timer == 2 && ocr > 255)
         {
           ocr = F_CPU / frequency / 2 / 32 - 1;
-          prescalarbits = 0b011;
+          prescalarbits = 0x03;
         }
 
         if (ocr > 255)
         {
           ocr = F_CPU / frequency / 2 / 64 - 1;
-          prescalarbits = _timer == 0 ? 0b011 : 0b100;
+          prescalarbits = _timer == 0 ? 0x03 : 0x04;
 
           if (_timer == 2 && ocr > 255)
           {
             ocr = F_CPU / frequency / 2 / 128 - 1;
-            prescalarbits = 0b101;
+            prescalarbits = 0x05;
           }
 
           if (ocr > 255)
           {
             ocr = F_CPU / frequency / 2 / 256 - 1;
-            prescalarbits = _timer == 0 ? 0b100 : 0b110;
+            prescalarbits = _timer == 0 ? 0x04 : 0x06;
             if (ocr > 255)
             {
               // can't do any better than /1024
               ocr = F_CPU / frequency / 2 / 1024 - 1;
-              prescalarbits = _timer == 0 ? 0b101 : 0b111;
+              prescalarbits = _timer == 0 ? 0x05 : 0x07;
             }
           }
         }
@@ -298,13 +298,13 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
 #if defined(TCCR0B)
       if (_timer == 0)
       {
-        TCCR0B = (TCCR0B & 0b11111000) | prescalarbits;
+        TCCR0B = (TCCR0B & 0xf8) | prescalarbits;
       }
       else
 #endif
 #if defined(TCCR2B)
       {
-        TCCR2B = (TCCR2B & 0b11111000) | prescalarbits;
+        TCCR2B = (TCCR2B & 0xf8) | prescalarbits;
       }
 #else
       {
@@ -317,30 +317,30 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
       // two choices for the 16 bit timers: ck/1 or ck/64
       ocr = F_CPU / frequency / 2 - 1;
 
-      prescalarbits = 0b001;
+      prescalarbits = 0x01;
       if (ocr > 0xffff)
       {
         ocr = F_CPU / frequency / 2 / 64 - 1;
-        prescalarbits = 0b011;
+        prescalarbits = 0x03;
       }
 
       if (_timer == 1)
       {
 #if defined(TCCR1B)
-        TCCR1B = (TCCR1B & 0b11111000) | prescalarbits;
+        TCCR1B = (TCCR1B & 0xf8) | prescalarbits;
 #endif
       }
 #if defined(TCCR3B)
       else if (_timer == 3)
-        TCCR3B = (TCCR3B & 0b11111000) | prescalarbits;
+        TCCR3B = (TCCR3B & 0xf8) | prescalarbits;
 #endif
 #if defined(TCCR4B)
       else if (_timer == 4)
-        TCCR4B = (TCCR4B & 0b11111000) | prescalarbits;
+        TCCR4B = (TCCR4B & 0xf8) | prescalarbits;
 #endif
 #if defined(TCCR5B)
       else if (_timer == 5)
-        TCCR5B = (TCCR5B & 0b11111000) | prescalarbits;
+        TCCR5B = (TCCR5B & 0xf8) | prescalarbits;
 #endif
 
     }
@@ -449,7 +449,7 @@ void disableTimer(uint8_t _timer)
         TCCR2A = (1 << WGM20);
       #endif
       #if defined(TCCR2B) && defined(CS22)
-        TCCR2B = (TCCR2B & 0b11111000) | (1 << CS22);
+        TCCR2B = (TCCR2B & 0xf8) | (1 << CS22);
       #endif
       #if defined(OCR2A)
         OCR2A = 0;


### PR DESCRIPTION
This "patch" will result in the suppression of a number of warnings that are the result of the use of binary constants, which a are not supported in ISO C++11. In particular the following warnings are removed.

```cpp
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/Tone.cpp:245:27: warning: binary constants are a C++14 feature or GCC extension
   uint8_t prescalarbits = 0b001;
                           ^~~~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/Tone.cpp:261:23: warning: binary constants are a C++14 feature or GCC extension
       prescalarbits = 0b001;  // ck/1: same for both timers
                       ^~~~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/Tone.cpp:265:25: warning: binary constants are a C++14 feature or GCC extension
         prescalarbits = 0b010;  // ck/8: same for both timers
                         ^~~~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/Tone.cpp:270:27: warning: binary constants are a C++14 feature or GCC extension
           prescalarbits = 0b011;
                           ^~~~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/Tone.cpp:276:41: warning: binary constants are a C++14 feature or GCC extension
           prescalarbits = _timer == 0 ? 0b011 : 0b100;
                                         ^~~~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/Tone.cpp:276:49: warning: binary constants are a C++14 feature or GCC extension
           prescalarbits = _timer == 0 ? 0b011 : 0b100;
                                                 ^~~~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/Tone.cpp:281:29: warning: binary constants are a C++14 feature or GCC extension
             prescalarbits = 0b101;
                             ^~~~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/Tone.cpp:287:43: warning: binary constants are a C++14 feature or GCC extension
             prescalarbits = _timer == 0 ? 0b100 : 0b110;
                                           ^~~~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/Tone.cpp:287:51: warning: binary constants are a C++14 feature or GCC extension
             prescalarbits = _timer == 0 ? 0b100 : 0b110;
                                                   ^~~~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/Tone.cpp:292:45: warning: binary constants are a C++14 feature or GCC extension
               prescalarbits = _timer == 0 ? 0b101 : 0b111;
                                             ^~~~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/Tone.cpp:292:53: warning: binary constants are a C++14 feature or GCC extension
               prescalarbits = _timer == 0 ? 0b101 : 0b111;
                                                     ^~~~~
.../.arduino15/packages/arduino/hardware/avr/1.8.5/cores/arduino/Tone.cpp:301:28: warning: binary constants are a C++14 feature or GCC extension
         TCCR0B = (TCCR0B & 0b11111000) | prescalarbits;
                            ^~~~~~~~~~
```

Note that these warnings only occur when using the `-pedantic` compiler option, which can be very useful for end users at times. So it would be nice if the user is not confronted with these warnings.