### PR TITLE
Fix weak attributions on operator new and delete

### DIFF
--- a/cores/arduino/new
+++ b/cores/arduino/new
@@ -39,25 +39,25 @@ namespace std {
   using size_t = ::size_t;
 } // namespace std
 
-[[gnu::weak]] void * operator new(std::size_t size);
-[[gnu::weak]] void * operator new[](std::size_t size);
+void * operator new(std::size_t size);
+void * operator new[](std::size_t size);
 
-[[gnu::weak]] void * operator new(std::size_t size, const std::nothrow_t tag) noexcept;
-[[gnu::weak]] void * operator new[](std::size_t size, const std::nothrow_t& tag) noexcept;
+void * operator new(std::size_t size, const std::nothrow_t tag) noexcept;
+void * operator new[](std::size_t size, const std::nothrow_t& tag) noexcept;
 
 void * operator new(std::size_t size, void *place) noexcept;
 void * operator new[](std::size_t size, void *place) noexcept;
 
-[[gnu::weak]] void operator delete(void * ptr) noexcept;
-[[gnu::weak]] void operator delete[](void * ptr) noexcept;
+void operator delete(void * ptr) noexcept;
+void operator delete[](void * ptr) noexcept;
 
 #if __cplusplus >= 201402L
-[[gnu::weak]] void operator delete(void* ptr, std::size_t size) noexcept;
-[[gnu::weak]] void operator delete[](void * ptr, std::size_t size) noexcept;
+void operator delete(void* ptr, std::size_t size) noexcept;
+void operator delete[](void * ptr, std::size_t size) noexcept;
 #endif // __cplusplus >= 201402L
 
-[[gnu::weak]] void operator delete(void* ptr, const std::nothrow_t& tag) noexcept;
-[[gnu::weak]] void operator delete[](void* ptr, const std::nothrow_t& tag) noexcept;
+void operator delete(void* ptr, const std::nothrow_t& tag) noexcept;
+void operator delete[](void* ptr, const std::nothrow_t& tag) noexcept;
 
 void operator delete(void* ptr, void* place) noexcept;
 void operator delete[](void* ptr, void* place) noexcept;

--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -44,7 +44,7 @@ static void * new_helper(std::size_t size) {
   return malloc(size);
 }
 
-void * operator new(std::size_t size) {
+[[gnu::weak]] void * operator new(std::size_t size) {
   void *res = new_helper(size);
 #if defined(NEW_TERMINATES_ON_FAILURE)
   if (!res)
@@ -52,11 +52,11 @@ void * operator new(std::size_t size) {
 #endif
   return res;
 }
-void * operator new[](std::size_t size) {
+[[gnu::weak]] void * operator new[](std::size_t size) {
   return operator new(size);
 }
 
-void * operator new(std::size_t size, [[gnu::unused]] const std::nothrow_t tag) noexcept {
+[[gnu::weak]] void * operator new(std::size_t size, [[gnu::unused]] const std::nothrow_t tag) noexcept {
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new as standard suggests, so call
   // new_helper directly then
@@ -65,7 +65,7 @@ void * operator new(std::size_t size, [[gnu::unused]] const std::nothrow_t tag) 
   return operator new(size);
 #endif
 }
-void * operator new[](std::size_t size, [[gnu::unused]] const std::nothrow_t& tag) noexcept {
+[[gnu::weak]] void * operator new[](std::size_t size, [[gnu::unused]] const std::nothrow_t& tag) noexcept {
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new[] as standard suggests, so call
   // malloc directly then
@@ -84,26 +84,26 @@ void * operator new[](std::size_t size, void *place) noexcept {
   return operator new(size, place);
 }
 
-void operator delete(void * ptr) noexcept {
+[[gnu::weak]] void operator delete(void * ptr) noexcept {
   free(ptr);
 }
-void operator delete[](void * ptr) noexcept {
+[[gnu::weak]] void operator delete[](void * ptr) noexcept {
   operator delete(ptr);
 }
 
 #if __cplusplus >= 201402L
-void operator delete(void* ptr, std::size_t size) noexcept {
+[[gnu::weak]] void operator delete(void* ptr, std::size_t size) noexcept {
   operator delete(ptr);
 }
-void operator delete[](void * ptr, std::size_t size) noexcept {
+[[gnu::weak]] void operator delete[](void * ptr, std::size_t size) noexcept {
   operator delete[](ptr);
 }
 #endif // __cplusplus >= 201402L
 
-void operator delete(void* ptr, [[gnu::unused]] const std::nothrow_t& tag) noexcept {
+[[gnu::weak]] void operator delete(void* ptr, [[gnu::unused]] const std::nothrow_t& tag) noexcept {
   operator delete(ptr);
 }
-void operator delete[](void* ptr, [[gnu::unused]] const std::nothrow_t& tag) noexcept {
+[[gnu::weak]] void operator delete[](void* ptr, [[gnu::unused]] const std::nothrow_t& tag) noexcept {
   operator delete[](ptr);
 }
 

--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -56,7 +56,7 @@ void * operator new[](std::size_t size) {
   return operator new(size);
 }
 
-void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
+void * operator new(std::size_t size, [[gnu::unused]] const std::nothrow_t tag) noexcept {
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new as standard suggests, so call
   // new_helper directly then
@@ -65,7 +65,7 @@ void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
   return operator new(size);
 #endif
 }
-void * operator new[](std::size_t size, const std::nothrow_t& tag) noexcept {
+void * operator new[](std::size_t size, [[gnu::unused]] const std::nothrow_t& tag) noexcept {
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new[] as standard suggests, so call
   // malloc directly then
@@ -100,10 +100,10 @@ void operator delete[](void * ptr, std::size_t size) noexcept {
 }
 #endif // __cplusplus >= 201402L
 
-void operator delete(void* ptr, const std::nothrow_t& tag) noexcept {
+void operator delete(void* ptr, [[gnu::unused]] const std::nothrow_t& tag) noexcept {
   operator delete(ptr);
 }
-void operator delete[](void* ptr, const std::nothrow_t& tag) noexcept {
+void operator delete[](void* ptr, [[gnu::unused]] const std::nothrow_t& tag) noexcept {
   operator delete[](ptr);
 }
 


### PR DESCRIPTION
When I introduced the weak attributes for various operator new and delete functions in #361, I accidentally put them in the header file instead of the source file. Fixing this is fairly trivial. See https://github.com/arduino/ArduinoCore-avr/pull/361#issuecomment-1161683551 and the commit message for details.

I based this PR on top of (a rebased version of) #456, since that PR touches a lot of the same lines (though is logically unrelated). We can either just merge this PR along with that commit, or merge that one first and I can rebase this one to drop the duplicate commit.