### PR TITLE
Added EEPROM support for `char*`, `char const*` and `String`.

### DIFF
--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -133,12 +133,39 @@ struct EEPROMClass{
         for( int count = sizeof(T) ; count ; --count, ++e )  *ptr++ = *e;
         return t;
     }
-    
+
+    String& get(int idx, String& data) {
+      data = "";
+      char c;
+      for (size_t i = idx; (c = get(i, c)); i++) {
+        data += c;
+      }
+      return data;
+    }
+
     template< typename T > const T &put( int idx, const T &t ){
         EEPtr e = idx;
         const uint8_t *ptr = (const uint8_t*) &t;
         for( int count = sizeof(T) ; count ; --count, ++e )  (*e).update( *ptr++ );
         return t;
+    }
+
+    char* put(int idx, char* data) {
+      size_t i;
+      for (i = 0; data[i]; i++) {
+        put(idx + i, data[i]);
+      }
+      put (idx + i, '\x00');
+      return data;
+    }
+
+    char const* put(int idx, char const* data) {
+      return put(idx, const_cast<char*>(data));
+    }
+
+    String& put(int idx, String& data) {
+      put(idx, data.c_str());
+      return data;
     }
 };
 


### PR DESCRIPTION
It seems that a number of people expect the EEPROM `put` and `get` functions to work with C strings and `String` objects [[1](https://forum.arduino.cc/t/is-it-recommended-to-space-out-eeprom-addresses-when-there-are-multiple-data-variables/997200), [2](https://forum.arduino.cc/t/how-to-store-the-serial-received-string-to-eeprom/1028193)]. This patch implements that functionality.

Example usage:

```cpp
char const* ccStr = "abc";
EEPROM.put(0, ccStr);
char cStr[] = "def";
EEPROM.put(5, cStr);
String sStr = "ghi";
EEPROM.put(10, sStr);

// ...

char cStr[10];  // Using standard `get` functionality.
Serial.println(EEPROM.get(0, cStr));   // Prints "abc".
Serial.println(EEPROM.get(5, cStr));   // Prints "def".
Serial.println(EEPROM.get(10, cStr));  // Prints "ghi".
String sStr;
Serial.println(EEPROM.get(0, sStr));   // Prints "abc".
Serial.println(EEPROM.get(5, sStr));   // Prints "def".
Serial.println(EEPROM.get(10, sStr));  // Prints "ghi".
}

// ...

// Verification, prints "abcÿdefÿghiÿ" (and three invisible characters).
for (size_t i = 0; i < 15; i++) {
  Serial.print(static_cast<char>(EEPROM.read(i)));
}
```

I hope you find this patch useful.