### PR TITLE
Fix spell check false positive by ignoring word

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = hart,pullrequest
+ignore-words-list = clen,hart,pullrequest
 builtin = clear
 check-filenames =
 check-hidden =


### PR DESCRIPTION
In the latest release of [the **codespell** tool](https://github.com/codespell-project/codespell) used for automated spell checking of the files of this project, the word "clen" was added to the codespell misspelled words dictionary as a misspelling of "clean" or "clan".

This caused a false detection of a struct member name `clen` as a misspelling, resulting in a failing spell check result:

https://github.com/arduino/ArduinoCore-avr/runs/7968491292?check_suite_focus=true#step:4:17

```text
Error: ./cores/arduino/USBCore.h:158: clen ==> clean, clan
Codespell found one or more problems
```

Since the occurrence of this name is correct and intended in this project, the false positive is resolved by configuring codespell to ignore the problematic word.