### PR TITLE
Make HardwareSerial compatible with ATmega16/32

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -138,7 +138,7 @@ void HardwareSerial::begin(unsigned long baud, byte config)
   _written = false;
 
   //set the data bits, parity, and stop bits
-#if defined(__AVR_ATmega8__)
+#if defined(__AVR_ATmega8__) || defined(__AVR_ATmega16__) || defined(__AVR_ATmega32__)
   config |= 0x80; // select UCSRC register (shared with UBRRH)
 #endif
   *_ucsrc = config;


### PR DESCRIPTION
ATmega8/16/32 all have a shared UCSRC/UBRRH register, and the high bit selects which one is being targeted.