### PR TITLE
Use correct quoting for paths in post_install.bat

### DIFF
--- a/post_install.bat
+++ b/post_install.bat
@@ -10,11 +10,11 @@ if "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
 
 REM dpinst /PATH has problems with relative paths, so use absolute path.
 if "%PROCESSOR_ARCHITECTURE%" == "AMD64" (
-  drivers\dpinst-amd64.exe /PATH %cd%\drivers\gemma %ARGS%
+  drivers\dpinst-amd64.exe /PATH "%cd%\drivers\gemma" %ARGS%
 ) ELSE IF "%PROCESSOR_ARCHITEW6432%" == "AMD64" (
-  drivers\dpinst-amd64.exe /PATH %cd%\drivers\gemma %ARGS%
+  drivers\dpinst-amd64.exe /PATH "%cd%\drivers\gemma" %ARGS%
 ) ELSE (
-  drivers\dpinst-x86.exe /PATH %cd%\drivers\gemma %ARGS%
+  drivers\dpinst-x86.exe /PATH "%cd%\drivers\gemma" %ARGS%
 )
 
 exit /b 0


### PR DESCRIPTION
Otherwise, the driver installation will fail if the current path contains spaces.

It may happen for example if the username has spaces in it: https://github.com/arduino/arduino-cli/issues/1926