### PR TITLE
Fix misspelled words in comments

### DIFF
--- a/bootloaders/atmega/ATmegaBOOT_168.c
+++ b/bootloaders/atmega/ATmegaBOOT_168.c
@@ -387,7 +387,7 @@ int main(void)
 	UCSR0C = (1<<UCSZ00) | (1<<UCSZ01);
 
 	/* Enable internal pull-up resistor on pin D0 (RX), in order
-	to supress line noise that prevents the bootloader from
+	to suppress line noise that prevents the bootloader from
 	timing out (DAM: 20070509) */
 	DDRD &= ~_BV(PIND0);
 	PORTD |= _BV(PIND0);
@@ -408,7 +408,7 @@ int main(void)
 
 #if defined __AVR_ATmega1280__
 	/* Enable internal pull-up resistor on pin D0 (RX), in order
-	to supress line noise that prevents the bootloader from
+	to suppress line noise that prevents the bootloader from
 	timing out (DAM: 20070509) */
 	/* feature added to the Arduino Mega --DC: 080930 */
 	DDRE &= ~_BV(PINE0);
@@ -447,7 +447,7 @@ int main(void)
 
 
 	/* Request programmer ID */
-	/* Not using PROGMEM string due to boot block in m128 being beyond 64kB boundry  */
+	/* Not using PROGMEM string due to boot block in m128 being beyond 64kB boundary  */
 	/* Would need to selectively manipulate RAMPZ, and it's only 9 characters anyway so who cares.  */
 	else if(ch=='1') {
 		if (getch() == ' ') {
@@ -730,7 +730,7 @@ int main(void)
 					if (!flags.rampz) putch(pgm_read_byte_near(address.word));
 #if defined(__AVR_ATmega128__) || defined(__AVR_ATmega1280__)
 					else putch(pgm_read_byte_far(address.word + 0x10000));
-					// Hmmmm, yuck  FIXME when m256 arrvies
+					// Hmmmm, yuck  FIXME when m256 arrives
 #endif
 					address.word++;
 				}

--- a/bootloaders/atmega8/ATmegaBOOT.c
+++ b/bootloaders/atmega8/ATmegaBOOT.c
@@ -199,7 +199,7 @@ int main(void)
 		}
 	
 		/* Request programmer ID */
-		/* Not using PROGMEM string due to boot block in m128 being beyond 64kB boundry  */
+		/* Not using PROGMEM string due to boot block in m128 being beyond 64kB boundary  */
 		/* Would need to selectively manipulate RAMPZ, and it's only 9 characters anyway so who cares.  */
 		else if(ch=='1') {
 			if (getch() == ' ') {
@@ -248,7 +248,7 @@ int main(void)
 		else if(ch=='P') {
 		  nothing_response();
 		  // FIXME: modified only here by DojoCorp, Mumbai, India, 20050626
-		  //time_count=0; // exted the delay once entered prog.mode
+		  //time_count=0; // extend the delay once entered prog.mode
 		}
 	
 		/* Leave programming mode  */

--- a/bootloaders/bt/ATmegaBOOT_168.c
+++ b/bootloaders/bt/ATmegaBOOT_168.c
@@ -465,7 +465,7 @@ putch(0x0D);
 
 
 	/* Request programmer ID */
-	/* Not using PROGMEM string due to boot block in m128 being beyond 64kB boundry  */
+	/* Not using PROGMEM string due to boot block in m128 being beyond 64kB boundary  */
 	/* Would need to selectively manipulate RAMPZ, and it's only 9 characters anyway so who cares.  */
 	else if(ch=='1') {
 	    if (getch() == ' ') {
@@ -727,7 +727,7 @@ putch(0x0D);
 			if (!flags.rampz) putch(pgm_read_byte_near(address.word));
 #if defined __AVR_ATmega128__
 			else putch(pgm_read_byte_far(address.word + 0x10000));
-			// Hmmmm, yuck  FIXME when m256 arrvies
+			// Hmmmm, yuck  FIXME when m256 arrives
 #endif
 			address.word++;
 		    }

--- a/bootloaders/caterina-Arduino_Robot/Makefile
+++ b/bootloaders/caterina-Arduino_Robot/Makefile
@@ -191,7 +191,7 @@ DEBUG = dwarf-2
 
 
 # List any extra directories to look for include files here.
-#     Each directory must be seperated by a space.
+#     Each directory must be separated by a space.
 #     Use forward slashes for directory separators.
 #     For a directory that has spaces, enclose it in quotes.
 EXTRAINCDIRS = $(LUFA_PATH)/
@@ -331,7 +331,7 @@ MATH_LIB = -lm
 
 
 # List any extra directories to look for libraries here.
-#     Each directory must be seperated by a space.
+#     Each directory must be separated by a space.
 #     Use forward slashes for directory separators.
 #     For a directory that has spaces, enclose it in quotes.
 EXTRALIBDIRS =

--- a/bootloaders/caterina-LilyPadUSB/Makefile
+++ b/bootloaders/caterina-LilyPadUSB/Makefile
@@ -180,7 +180,7 @@ DEBUG = dwarf-2
 
 
 # List any extra directories to look for include files here.
-#     Each directory must be seperated by a space.
+#     Each directory must be separated by a space.
 #     Use forward slashes for directory separators.
 #     For a directory that has spaces, enclose it in quotes.
 EXTRAINCDIRS = $(LUFA_PATH)/
@@ -320,7 +320,7 @@ MATH_LIB = -lm
 
 
 # List any extra directories to look for libraries here.
-#     Each directory must be seperated by a space.
+#     Each directory must be separated by a space.
 #     Use forward slashes for directory separators.
 #     For a directory that has spaces, enclose it in quotes.
 EXTRALIBDIRS =

--- a/bootloaders/caterina/Makefile
+++ b/bootloaders/caterina/Makefile
@@ -187,7 +187,7 @@ DEBUG = dwarf-2
 
 
 # List any extra directories to look for include files here.
-#     Each directory must be seperated by a space.
+#     Each directory must be separated by a space.
 #     Use forward slashes for directory separators.
 #     For a directory that has spaces, enclose it in quotes.
 EXTRAINCDIRS = $(LUFA_PATH)/
@@ -327,7 +327,7 @@ MATH_LIB = -lm
 
 
 # List any extra directories to look for libraries here.
-#     Each directory must be seperated by a space.
+#     Each directory must be separated by a space.
 #     Use forward slashes for directory separators.
 #     For a directory that has spaces, enclose it in quotes.
 EXTRALIBDIRS =

--- a/bootloaders/gemma/avrdude.conf
+++ b/bootloaders/gemma/avrdude.conf
@@ -170,7 +170,7 @@
 #
 # INSTRUCTION FORMATS
 #
-#    Instruction formats are specified as a comma seperated list of
+#    Instruction formats are specified as a comma separated list of
 #    string values containing information (bit specifiers) about each
 #    of the 32 bits of the instruction.  Bit specifiers may be one of
 #    the following formats:
@@ -365,7 +365,7 @@ programmer
 # http://flashrom.org/FT2232SPI_Programmer
 # 
 # The drivers will look for a specific device and use the first one found.
-# If you have mulitple devices, then look for unique information (like SN)
+# If you have multiple devices, then look for unique information (like SN)
 # And fill that in here.
 #
 # Note that the pin numbers for the main ISP signals (reset, sck,

--- a/bootloaders/lilypad/src/ATmegaBOOT.c
+++ b/bootloaders/lilypad/src/ATmegaBOOT.c
@@ -330,7 +330,7 @@ int main(void)
     UCSR0C = (1<<UCSZ00) | (1<<UCSZ01);
 
     /* Enable internal pull-up resistor on pin D0 (RX), in order
-    to supress line noise that prevents the bootloader from
+    to suppress line noise that prevents the bootloader from
     timing out (DAM: 20070509) */
     DDRD &= ~_BV(PIND0);
     PORTD |= _BV(PIND0);
@@ -381,7 +381,7 @@ int main(void)
 
 
 	/* Request programmer ID */
-	/* Not using PROGMEM string due to boot block in m128 being beyond 64kB boundry  */
+	/* Not using PROGMEM string due to boot block in m128 being beyond 64kB boundary  */
 	/* Would need to selectively manipulate RAMPZ, and it's only 9 characters anyway so who cares.  */
 	else if(ch=='1') {
 	    if (getch() == ' ') {
@@ -649,7 +649,7 @@ int main(void)
 			if (!flags.rampz) putch(pgm_read_byte_near(address.word));
 #if defined __AVR_ATmega128__
 			else putch(pgm_read_byte_far(address.word + 0x10000));
-			// Hmmmm, yuck  FIXME when m256 arrvies
+			// Hmmmm, yuck  FIXME when m256 arrives
 #endif
 			address.word++;
 		    }

--- a/bootloaders/stk500v2/Makefile
+++ b/bootloaders/stk500v2/Makefile
@@ -90,7 +90,7 @@ DEBUG = dwarf-2
 
 
 # List any extra directories to look for include files here.
-#     Each directory must be seperated by a space.
+#     Each directory must be separated by a space.
 #     Use forward slashes for directory separators.
 #     For a directory that has spaces, enclose it in quotes.
 EXTRAINCDIRS = 

--- a/cores/arduino/CDC.cpp
+++ b/cores/arduino/CDC.cpp
@@ -119,7 +119,7 @@ bool CDC_Setup(USBSetup& setup)
 			// For future boards save the key in the inproblematic RAMEND
 			// Which is reserved for the main() return value (which will never return)
 			if (isLUFAbootloader()) {
-				// horray, we got a new bootloader!
+				// hooray, we got a new bootloader!
 				magic_key_pos = (RAMEND-1);
 			}
 #endif

--- a/cores/arduino/USBCore.h
+++ b/cores/arduino/USBCore.h
@@ -191,7 +191,7 @@ typedef struct
 } EndpointDescriptor;
 
 // Interface Association Descriptor
-// Used to bind 2 interfaces together in CDC compostite device
+// Used to bind 2 interfaces together in CDC composite device
 typedef struct
 {
 	u8 len;				// 8

--- a/firmwares/atmegaxxu2/arduino-usbdfu/makefile
+++ b/firmwares/atmegaxxu2/arduino-usbdfu/makefile
@@ -171,7 +171,7 @@ DEBUG = dwarf-2
 
 
 # List any extra directories to look for include files here.
-#     Each directory must be seperated by a space.
+#     Each directory must be separated by a space.
 #     Use forward slashes for directory separators.
 #     For a directory that has spaces, enclose it in quotes.
 EXTRAINCDIRS = $(LUFA_PATH)/
@@ -310,7 +310,7 @@ MATH_LIB = -lm
 
 
 # List any extra directories to look for libraries here.
-#     Each directory must be seperated by a space.
+#     Each directory must be separated by a space.
 #     Use forward slashes for directory separators.
 #     For a directory that has spaces, enclose it in quotes.
 EXTRALIBDIRS = 

--- a/firmwares/atmegaxxu2/arduino-usbserial/makefile
+++ b/firmwares/atmegaxxu2/arduino-usbserial/makefile
@@ -188,7 +188,7 @@ DEBUG = dwarf-2
 
 
 # List any extra directories to look for include files here.
-#     Each directory must be seperated by a space.
+#     Each directory must be separated by a space.
 #     Use forward slashes for directory separators.
 #     For a directory that has spaces, enclose it in quotes.
 EXTRAINCDIRS = $(LUFA_PATH)/
@@ -328,7 +328,7 @@ MATH_LIB = -lm
 
 
 # List any extra directories to look for libraries here.
-#     Each directory must be seperated by a space.
+#     Each directory must be separated by a space.
 #     Use forward slashes for directory separators.
 #     For a directory that has spaces, enclose it in quotes.
 EXTRALIBDIRS = 


### PR DESCRIPTION
This project uses the [**codespell** tool](https://github.com/codespell-project/codespell) to check for commonly misspelled words in the files of the repository.

A recent update to the tool's misspelled words dictionary resulted in the identification of some occurrences of a misspelled word in the comments:

https://github.com/arduino/ArduinoCore-avr/actions/runs/3272628064/jobs/5383865750#step:4:17

```text
Error: ./firmwares/atmegaxxu2/arduino-usbdfu/makefile:[17](https://github.com/arduino/ArduinoCore-avr/actions/runs/3272628064/jobs/5383865750#step:4:18)4: seperated ==> separated
Error: ./firmwares/atmegaxxu2/arduino-usbdfu/makefile:313: seperated ==> separated
Error: ./firmwares/atmegaxxu2/arduino-usbserial/makefile:[19](https://github.com/arduino/ArduinoCore-avr/actions/runs/3272628064/jobs/5383865750#step:4:20)1: seperated ==> separated
Error: ./firmwares/atmegaxxu2/arduino-usbserial/makefile:331: seperated ==> separated
```

In addition to correcting the detected misspellings, I did a quick scan over the repository and identified a few additional misspellings to correct.