### PR TITLE
Added printf() to Print class

### DIFF
--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -41,6 +41,36 @@ size_t Print::write(const uint8_t *buffer, size_t size)
   return n;
 }
 
+size_t Print::printf(const char *format, ...)
+{
+    char loc_buf[64];
+    char * temp = loc_buf;
+    va_list arg;
+    va_list copy;
+    va_start(arg, format);
+    va_copy(copy, arg);
+    int len = vsnprintf(temp, sizeof(loc_buf), format, copy);
+    va_end(copy);
+    if(len < 0) {
+        va_end(arg);
+        return 0;
+    };
+    if((unsigned)len >= sizeof(loc_buf)){
+        temp = (char*) malloc(len+1);
+        if(temp == NULL) {
+            va_end(arg);
+            return 0;
+        }
+        len = vsnprintf(temp, len+1, format, arg);
+    }
+    va_end(arg);
+    len = write((uint8_t*)temp, len);
+    if(temp != loc_buf){
+        free(temp);
+    }
+    return len;
+}
+
 size_t Print::print(const __FlashStringHelper *ifsh)
 {
   PGM_P p = reinterpret_cast<PGM_P>(ifsh);

--- a/cores/arduino/Print.h
+++ b/cores/arduino/Print.h
@@ -57,6 +57,8 @@ class Print
     size_t write(const char *buffer, size_t size) {
       return write((const uint8_t *)buffer, size);
     }
+  
+    size_t printf(const char * format, ...)  __attribute__ ((format (printf, 2, 3)));
 
     // default to zero, meaning "a single write may block"
     // should be overridden by subclasses with buffering


### PR DESCRIPTION
This PR is a carbon copy of printf() implementation as found on some core packages such as esp8266 or esp32.

It enables simple stuff like this:

```cpp
Serial.printf("%s %s\n", "hello", "world");
```

The `Print` class is inherited by `Stream` and any class that implements `Print` e.g. `fs::File`, `SoftwareSerial`, `HardwareSerial`, `USB`, `Udp`, `Wire`.

