### PR TITLE
Adding peekLast() to HW serial library

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -177,6 +177,11 @@ int HardwareSerial::peek(void)
   }
 }
 
+int HardwareSerial::peekLast(void)
+{
+  return _rx_buffer_head==_rx_buffer_tail ? -1 : _rx_buffer[(SERIAL_RX_BUFFER_SIZE+_rx_buffer_tail-1)%SERIAL_RX_BUFFER_SIZE];
+}
+
 int HardwareSerial::read(void)
 {
   // if the head isn't ahead of the tail, we don't have any characters

--- a/cores/arduino/HardwareSerial.h
+++ b/cores/arduino/HardwareSerial.h
@@ -123,6 +123,7 @@ class HardwareSerial : public Stream
     void end();
     virtual int available(void);
     virtual int peek(void);
+    virtual int peekLast(void);
     virtual int read(void);
     virtual int availableForWrite(void);
     virtual void flush(void);


### PR DESCRIPTION
### Justification:
Peek is insufficient to glean data in the serial queue, it is often needed to look at the last character in the buffer.

### Implementation:
Added peekLast() method to allow peeking at the last character in the buffer.
The method follows behavior of other peek and read method, has no input or output parameters, uses integer for return data type and returns -1 if the queue is empty.

### Testing/Validation:
Tested with multiple different queue sizes, including 0. Ops check good.