### PR TITLE
Fix digitalRead for controllers with big flash

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -175,13 +175,22 @@ extern const uint8_t PROGMEM digital_pin_to_timer_PGM[];
 // 
 // These perform slightly better as macros compared to inline functions
 //
+#define analogInPinToBit(P) (P)
+#if (FLASHEND > 0xFFFF)
+#define digitalPinToPort(P) ( pgm_read_byte_far( pgm_get_far_address( digital_pin_to_port_PGM ) + (P) ) )
+#define digitalPinToBitMask(P) ( pgm_read_byte_far( pgm_get_far_address( digital_pin_to_bit_mask_PGM ) + (P) ) )
+#define digitalPinToTimer(P) ( pgm_read_byte_far( pgm_get_far_address( digital_pin_to_timer_PGM ) + (P) ) )
+#define portOutputRegister(P) ( (volatile uint8_t *)( pgm_read_word_far( pgm_get_far_address( port_to_output_PGM ) + 2 * (P))) )
+#define portInputRegister(P) ( (volatile uint8_t *)( pgm_read_word_far( pgm_get_far_address( port_to_input_PGM ) + 2 * (P))) )
+#define portModeRegister(P) ( (volatile uint8_t *)( pgm_read_word_far( pgm_get_far_address( port_to_mode_PGM ) + 2 * (P))) )
+#else
 #define digitalPinToPort(P) ( pgm_read_byte( digital_pin_to_port_PGM + (P) ) )
 #define digitalPinToBitMask(P) ( pgm_read_byte( digital_pin_to_bit_mask_PGM + (P) ) )
 #define digitalPinToTimer(P) ( pgm_read_byte( digital_pin_to_timer_PGM + (P) ) )
-#define analogInPinToBit(P) (P)
 #define portOutputRegister(P) ( (volatile uint8_t *)( pgm_read_word( port_to_output_PGM + (P))) )
 #define portInputRegister(P) ( (volatile uint8_t *)( pgm_read_word( port_to_input_PGM + (P))) )
 #define portModeRegister(P) ( (volatile uint8_t *)( pgm_read_word( port_to_mode_PGM + (P))) )
+#endif
 
 #define NOT_A_PIN 0
 #define NOT_A_PORT 0


### PR DESCRIPTION
avr-gcc uses 16-bit type for the pointers. Therefore for when PGM data moves above 64k, it can't be read with pgm_read_word(name).
It can be fixed by retrieving full data address with pgm_get_far_address.
This patch fixes digital pin-related macros, that failed to work on AVR Mega with firmware larger than 64k.