### PR TITLE
Make ISR(Timer0_OVF_vect) a weak function

### DIFF
--- a/cores/arduino/wiring.c
+++ b/cores/arduino/wiring.c
@@ -40,9 +40,9 @@ volatile unsigned long timer0_millis = 0;
 static unsigned char timer0_fract = 0;
 
 #if defined(TIM0_OVF_vect)
-ISR(TIM0_OVF_vect)
+ISR(TIM0_OVF_vect,  __attribute__((weak))))
 #else
-ISR(TIMER0_OVF_vect)
+ISR(TIMER0_OVF_vect,  __attribute__((weak)))
 #endif
 {
 	// copy these to local variables so they can be stored in registers


### PR DESCRIPTION
In order to let people use Timer0 with all its functions, mark this with the attribute 'weak', so they can redefine this function with their own code.