### PR TITLE
Update Stream.cpp

### DIFF
--- a/cores/arduino/Stream.cpp
+++ b/cores/arduino/Stream.cpp
@@ -160,7 +160,7 @@ float Stream::parseFloat(LookaheadMode lookahead, char ignore)
 {
   bool isNegative = false;
   bool isFraction = false;
-  long value = 0;
+  float value = 0;
   int c;
   float fraction = 1.0;
 


### PR DESCRIPTION
prevent `long int` overflow when too many digits. This change will only return the most significant digits.
Issue #468