### PR TITLE
use less stack on Print::printNumber

### DIFF
--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -208,7 +208,7 @@ size_t Print::printNumber(unsigned long n, uint8_t base)
   }
 
   // prevent crash if called with base == 1
-  if (base < 2) base = 10;
+  if (base < 2) return printNumber(n, 10);
 
 // use -D ARDUINO_PRINT_NUMBER_GENERIC_ONLY when compiling to get only the generic version
 #ifndef ARDUINO_PRINT_NUMBER_GENERIC_ONLY

--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -227,7 +227,6 @@ size_t Print::printNumber(unsigned long n, uint8_t base)
           } // else: skip leading zeros
           c = access[i] & 0x0f;
           if (c != 0 || written != 0) {
-            // skip leading zeros
             c = (c < 10 ? c + '0' : c + 'A' - 10);
             written += write(c);
           } // else: skip leading zeros

--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -202,7 +202,7 @@ size_t Print::println(const Printable& x)
 
 size_t Print::printNumber(unsigned long n, uint8_t base)
 {
-  // shortcut printing just 0 prevents later overhead
+  // shortcut printing just 0 and prevent later overhead
   if (n == 0) {
     return write('0');
   }
@@ -212,6 +212,10 @@ size_t Print::printNumber(unsigned long n, uint8_t base)
 
   unsigned long reverse = 0;
   uint8_t digits = 0;
+  char avoid_overflow = n % base;
+
+  // this step and 'avoid_overflow' will make sure it stays in unsigned long range beeing able to print all 10 digits no matter what
+  n /= base;
 
   // reverse the number and count digits
   while (n != 0) {
@@ -222,13 +226,16 @@ size_t Print::printNumber(unsigned long n, uint8_t base)
   }
   
   // from here onwards reuse of variable 'n' to count written chars
-  do {
+  while (digits--) {
     char c = reverse % base;
     reverse /= base;
 
     c = (c < 10 ? c + '0' : c + 'A' - 10);
     n += write(c);
-  } while(--digits);
+  }
+
+  avoid_overflow = (avoid_overflow < 10 ? avoid_overflow + '0' : avoid_overflow + 'A' - 10);
+  n += write(avoid_overflow);
 
   return n;
 }

--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -202,22 +202,35 @@ size_t Print::println(const Printable& x)
 
 size_t Print::printNumber(unsigned long n, uint8_t base)
 {
-  char buf[8 * sizeof(long) + 1]; // Assumes 8-bit chars plus zero byte.
-  char *str = &buf[sizeof(buf) - 1];
-
-  *str = '\0';
+  // shortcut printing just 0 prevents later overhead
+  if (n == 0) {
+    return write('0');
+  }
 
   // prevent crash if called with base == 1
   if (base < 2) base = 10;
 
-  do {
-    char c = n % base;
+  unsigned long reverse = 0;
+  uint8_t digits = 0;
+
+  // reverse the number and count digits
+  while (n != 0) {
+    uint8_t remainder = n % base;
+    reverse = reverse * base + remainder;
     n /= base;
+    digits++;
+  }
+  
+  // from here onwards reuse of variable 'n' to count written chars
+  do {
+    char c = reverse % base;
+    reverse /= base;
 
-    *--str = c < 10 ? c + '0' : c + 'A' - 10;
-  } while(n);
+    c = (c < 10 ? c + '0' : c + 'A' - 10);
+    n += write(c);
+  } while(--digits);
 
-  return write(str);
+  return n;
 }
 
 size_t Print::printFloat(double number, uint8_t digits) 

--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -218,7 +218,7 @@ size_t Print::printNumber(unsigned long n, uint8_t base)
     {
       uint8_t *access = (uint8_t*) &n;
       uint8_t written = 0;
-      for (int8_t i=3; i>=0; i--) {
+      for (int8_t i=sizeof(unsigned long)-1; i>=0; i--) {
           char c;
           c = (access[i] & 0xf0) >> 4;
           if (c != 0 || written != 0) {
@@ -238,7 +238,7 @@ size_t Print::printNumber(unsigned long n, uint8_t base)
     {
       uint8_t *access = (uint8_t*) &n;
       uint8_t written = 0;
-      for (int8_t i=3; i>=0; i--) {
+      for (int8_t i=sizeof(unsigned long)-1; i>=0; i--) {
         if (access[i] == 0 && written == 0) {
             // skip leading zeros
             continue;

--- a/cores/arduino/Print.cpp
+++ b/cores/arduino/Print.cpp
@@ -269,7 +269,7 @@ size_t Print::printNumber(unsigned long n, uint8_t base)
       uint8_t digits = 0;
       char avoid_overflow = n % base;
 
-      // this step and 'avoid_overflow' will make sure it stays in unsigned long range beeing able to print all 10 digits no matter what
+      // this step and 'avoid_overflow' will make sure it stays in unsigned long range being able to print all 10 digits no matter what
       n /= base;
 
       // reverse the number and count digits


### PR DESCRIPTION
The issue with printNumber is that it uses a lot of stack quite unexpectedly. This makes it basically unusable on a attiny.
I suggest doing the naive implementation as it's done with float print. 

I think the Autor was hoping for a more optimized write call Implementation in the over-writable write call with a long buffer. I think this is too late to get it more efficient for most platforms anyway. Another option of course would be changing the API and adding a parameter for this or adding a define to switch the default Implementation.