### PR TITLE
Updated Tone.cpp to allow specifying pin state on noTone

### DIFF
--- a/cores/arduino/Arduino.h
+++ b/cores/arduino/Arduino.h
@@ -246,6 +246,7 @@ unsigned long pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout = 10
 
 void tone(uint8_t _pin, unsigned int frequency, unsigned long duration = 0);
 void noTone(uint8_t _pin);
+void noTone(uint8_t _pin, bool _exit_state);
 
 // WMath prototypes
 long random(long);

--- a/cores/arduino/Tone.cpp
+++ b/cores/arduino/Tone.cpp
@@ -494,6 +494,23 @@ void noTone(uint8_t _pin)
   digitalWrite(_pin, 0);
 }
 
+
+void noTone(uint8_t _pin, bool _exit_state)
+{
+  int8_t _timer = -1;
+
+  for (int i = 0; i < AVAILABLE_TONE_PINS; i++) {
+    if (tone_pins[i] == _pin) {
+      _timer = pgm_read_byte(tone_pin_to_timer_PGM + i);
+      tone_pins[i] = 255;
+      break;
+    }
+  }
+
+  disableTimer(_timer);
+  digitalWrite(_pin, _exit_state);
+}
+
 #ifdef USE_TIMER0
 ISR(TIMER0_COMPA_vect)
 {


### PR DESCRIPTION
Pull request addresses issue #489. Adds support for passive buzzers with inverted logic, which beep on LOW instead of HIGH. The current work-around is to call digitalWrite(pin, HIGH) after calling noTone(), however it causes a "click" sound after the tone has played.

With this change, the pin state can be specified in Tone.cpp is inverted, so passive buzzers with either normal or inverted logic can be used with tone() without any work-around. 

The original function is still present, the new function builds on that as a template.

First pull request 🚀🚀🚀! So glad I got here👋