### PR TITLE
Fix micros() underestimation for 12MHz

### DIFF
--- a/cores/arduino/wiring.c
+++ b/cores/arduino/wiring.c
@@ -100,7 +100,7 @@ unsigned long micros() {
 
 	SREG = oldSREG;
 	
-	return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
+	return clockCyclesToMicroseconds(((m << 8) + t) * 64);
 }
 
 void delay(unsigned long ms)


### PR DESCRIPTION
When the clock is not the divisors of 64 (e.x. 12 MHz), micros() returns an underestimated value.
It's better to use clockCyclesToMicroseconds.

```
e.g.
((m << 8) + t) * (64 / clockCyclesPerMicrosecond())
 ^^^^^^^^^^^^^:A

When the clock is 12MHz and the part A is 1000 (m = 3, t = 232), this calculation results in 5000.
(Should be 5333.)
```