### PR TITLE
Fix compilation warnings about unused parameter "tag" in file `new.cpp`

### DIFF
--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -57,6 +57,7 @@ void * operator new[](std::size_t size) {
 }
 
 void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
+  (void)tag; // unused
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new as standard suggests, so call
   // new_helper directly then
@@ -66,6 +67,7 @@ void * operator new(std::size_t size, const std::nothrow_t tag) noexcept {
 #endif
 }
 void * operator new[](std::size_t size, const std::nothrow_t& tag) noexcept {
+  (void)tag; // unused
 #if defined(NEW_TERMINATES_ON_FAILURE)
   // Cannot call throwing operator new[] as standard suggests, so call
   // malloc directly then
@@ -101,9 +103,11 @@ void operator delete[](void * ptr, std::size_t size) noexcept {
 #endif // __cplusplus >= 201402L
 
 void operator delete(void* ptr, const std::nothrow_t& tag) noexcept {
+  (void)tag; // unused
   operator delete(ptr);
 }
 void operator delete[](void* ptr, const std::nothrow_t& tag) noexcept {
+  (void)tag; // unused
   operator delete[](ptr);
 }
 


### PR DESCRIPTION
Fix compilation warning on file `cores/arduino/new.cpp` about unused argument `tag` in four of the functions by casting the argument to void.