### PR TITLE
Reserve the correct (smaller) amount of flash for Optiboot on the Arduino Nano.

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -213,12 +213,12 @@ nano.build.variant=eightanaloginputs
 ## --------------------------
 nano.menu.cpu.atmega328=ATmega328P
 
-nano.menu.cpu.atmega328.upload.maximum_size=30720
+nano.menu.cpu.atmega328.upload.maximum_size=32256
 nano.menu.cpu.atmega328.upload.maximum_data_size=2048
 nano.menu.cpu.atmega328.upload.speed=115200
 
 nano.menu.cpu.atmega328.bootloader.low_fuses=0xFF
-nano.menu.cpu.atmega328.bootloader.high_fuses=0xDA
+nano.menu.cpu.atmega328.bootloader.high_fuses=0xDE
 nano.menu.cpu.atmega328.bootloader.extended_fuses=0xFD
 nano.menu.cpu.atmega328.bootloader.file=optiboot/optiboot_atmega328.hex
 


### PR DESCRIPTION
Two variants of the Arduino Nano board are supported: one using an old
boot loader; the other the new, smaller, optiboot.

However, the flags which protect memory and the memory reserved for
the boot loader when linking haven't been updated for optiboot. This
PR fixes that.