### PR TITLE
Shorten critical section in micros()

### DIFF
--- a/cores/arduino/wiring.c
+++ b/cores/arduino/wiring.c
@@ -78,7 +78,7 @@ unsigned long millis()
 
 unsigned long micros() {
 	unsigned long m;
-	uint8_t oldSREG = SREG, t;
+	uint8_t oldSREG = SREG, t, flags;
 	
 	cli();
 	m = timer0_overflow_count;
@@ -91,14 +91,15 @@ unsigned long micros() {
 #endif
 
 #ifdef TIFR0
-	if ((TIFR0 & _BV(TOV0)) && (t < 255))
-		m++;
+	flags = TIFR0;
 #else
-	if ((TIFR & _BV(TOV0)) && (t < 255))
-		m++;
+	flags = TIFR;
 #endif
 
 	SREG = oldSREG;
+
+	if ((flags & _BV(TOV0)) && (t < 255))
+		m++;
 	
 	return ((m << 8) + t) * (64 / clockCyclesPerMicrosecond());
 }


### PR DESCRIPTION
The critical section in `micros()` is longer than it needs to be. The interrupt flag register has to be read within the critical section, but testing whether the overflow count should be incremented can be done with interrupts enabled.

Without this pull request, compiling for an UNO I get this critical section:

```asm
    in   r19, SREG
    cli
    lds  r24, timer0_overflow_count
    lds  r25, timer0_overflow_count+0x1
    lds  r26, timer0_overflow_count+0x2
    lds  r27, timer0_overflow_count+0x3
    in   r18, TCNT0
    sbis TIFR0, 0
    rjmp 1f
    cpi  r18, 255
    breq 1f
    adiw r24, 0x01
    adc  r26, r1
    adc  r27, r1
1:  out  SREG, r19
```

With the pull request applied, this becomes:

```asm
    in   r20, SREG
    cli
    lds  r24, timer0_overflow_count
    lds  r25, timer0_overflow_count+0x1
    lds  r26, timer0_overflow_count+0x2
    lds  r27, timer0_overflow_count+0x3
    in   r18, TCNT0
    in   r19, TIFR0
    out  SREG, r20
```

which saves us between 2 and 7 cycles of critical section.