### PR TITLE
Add virtual destructor to avoid compiler warning on undefined behavior

### DIFF
--- a/cores/arduino/Server.h
+++ b/cores/arduino/Server.h
@@ -25,6 +25,7 @@
 class Server : public Print {
 public:
   virtual void begin() =0;
+  virtual ~Server() {}
 };
 
 #endif


### PR DESCRIPTION
The `Server` class is virtual (`begin()` is not defined).
Standard thus requires to have the destructor virtual, otherwise undefined behaviour is expected.

This PR suggest to fix this issue by adding a simple empty destructor.