### PR TITLE
Expose MCUSR register to applications using GPIOR0

### DIFF
--- a/bootloaders/caterina/Caterina.h
+++ b/bootloaders/caterina/Caterina.h
@@ -86,7 +86,7 @@
 		typedef void (*AppPtr_t)(void) ATTR_NO_RETURN;
 
 	/* Function Prototypes: */
-		void StartSketch(void);
+		void StartSketch(uint8_t mcur_state);
 		void LEDPulse(void);
 	
 		void CDC_Task(void);


### PR DESCRIPTION
This allows applications to handle reset reasons, e.g. watchdog, reset button, ... by reading a general purpose register (GPIOR0) without affecting current MCUSR implementation.