### PR TITLE
Quick Fix of overflow for larger toggle_count values

### DIFF
--- a/cores/arduino/Tone.cpp
+++ b/cores/arduino/Tone.cpp
@@ -349,7 +349,7 @@ void tone(uint8_t _pin, unsigned int frequency, unsigned long duration)
     // Calculate the toggle count
     if (duration > 0)
     {
-      toggle_count = 2 * frequency * duration / 1000;
+      toggle_count = 2 * (unsigned long)frequency * duration / 1000;
     }
     else
     {


### PR DESCRIPTION
Quick Fix of overflow for larger `toggle_count` values. Because of the 16-bit `int` value in many platforms including Uno, the calculation of `toggle_count` overflows easily. For example with a frequency of 39kHz and a duration of 9ms, you get `toggle_count == 112 `, which is 1.5ms.