### PR TITLE
HID_: Make methods overridden from base-class explicit

### DIFF
--- a/libraries/HID/src/HID.h
+++ b/libraries/HID/src/HID.h
@@ -98,10 +98,10 @@ public:
 
 protected:
   // Implementation of the PluggableUSBModule
-  int getInterface(uint8_t* interfaceCount);
-  int getDescriptor(USBSetup& setup);
-  bool setup(USBSetup& setup);
-  uint8_t getShortName(char* name);
+  int getInterface(uint8_t* interfaceCount) override;
+  int getDescriptor(USBSetup& setup) override;
+  bool setup(USBSetup& setup) override;
+  uint8_t getShortName(char* name) override;
 
 private:
   uint8_t epType[1];


### PR DESCRIPTION
Done to make it clear that these virtual methods are defined in the `PluggableUSBModule` base-class.

I'm willing to also submit PR's for also updating the corresponding implementation in the other Arduino repos (ArduinoCore-samd, ArduinoCore-sam) if desired.