### PR TITLE
HID: Remove empty HID_::begin() method to simplify

### DIFF
--- a/libraries/HID/src/HID.cpp
+++ b/libraries/HID/src/HID.cpp
@@ -154,9 +154,4 @@ HID_::HID_(void) : PluggableUSBModule(1, 1, epType),
 	PluggableUSB().plug(this);
 }
 
-int HID_::begin(void)
-{
-	return 0;
-}
-
 #endif /* if defined(USBCON) */

--- a/libraries/HID/src/HID.h
+++ b/libraries/HID/src/HID.h
@@ -92,7 +92,6 @@ class HID_ : public PluggableUSBModule
 {
 public:
   HID_(void);
-  int begin(void);
   int SendReport(uint8_t id, const void* data, int len);
   void AppendDescriptor(HIDSubDescriptor* node);
 


### PR DESCRIPTION
This method doesn't do anything, so I'm proposing to remove it to make the class easier to understand for new developers.

I'm willing to also submit PR's for also updating the corresponding implementation in the other Arduino repos (ArduinoCore-samd, ArduinoCore-sam) if desired.