### PR TITLE
HID: Initialize class members in header instead of cpp

### DIFF
--- a/libraries/HID/src/HID.cpp
+++ b/libraries/HID/src/HID.cpp
@@ -148,7 +148,7 @@ bool HID_::setup(USBSetup& setup)
 
 HID_::HID_(void) : PluggableUSBModule(1, 1, epType),
                    rootNode(NULL),
-                   protocol(HID_REPORT_PROTOCOL), idle(1)
+                   protocol(HID_REPORT_PROTOCOL)
 {
 	epType[0] = EP_TYPE_INTERRUPT_IN;
 	PluggableUSB().plug(this);

--- a/libraries/HID/src/HID.cpp
+++ b/libraries/HID/src/HID.cpp
@@ -147,7 +147,7 @@ bool HID_::setup(USBSetup& setup)
 }
 
 HID_::HID_(void) : PluggableUSBModule(1, 1, epType),
-                   rootNode(NULL), descriptorSize(0),
+                   rootNode(NULL),
                    protocol(HID_REPORT_PROTOCOL), idle(1)
 {
 	epType[0] = EP_TYPE_INTERRUPT_IN;

--- a/libraries/HID/src/HID.cpp
+++ b/libraries/HID/src/HID.cpp
@@ -147,8 +147,7 @@ bool HID_::setup(USBSetup& setup)
 }
 
 HID_::HID_(void) : PluggableUSBModule(1, 1, epType),
-                   rootNode(NULL),
-                   protocol(HID_REPORT_PROTOCOL)
+                   rootNode(NULL)
 {
 	epType[0] = EP_TYPE_INTERRUPT_IN;
 	PluggableUSB().plug(this);

--- a/libraries/HID/src/HID.cpp
+++ b/libraries/HID/src/HID.cpp
@@ -146,8 +146,7 @@ bool HID_::setup(USBSetup& setup)
 	return false;
 }
 
-HID_::HID_(void) : PluggableUSBModule(1, 1, epType),
-                   rootNode(NULL)
+HID_::HID_(void) : PluggableUSBModule(1, 1, epType)
 {
 	epType[0] = EP_TYPE_INTERRUPT_IN;
 	PluggableUSB().plug(this);

--- a/libraries/HID/src/HID.h
+++ b/libraries/HID/src/HID.h
@@ -106,7 +106,7 @@ protected:
 private:
   uint8_t epType[1];
 
-  HIDSubDescriptor* rootNode;
+  HIDSubDescriptor* rootNode = NULL;
   uint16_t descriptorSize = 0;
 
   uint8_t protocol = HID_REPORT_PROTOCOL;

--- a/libraries/HID/src/HID.h
+++ b/libraries/HID/src/HID.h
@@ -109,7 +109,7 @@ private:
   HIDSubDescriptor* rootNode;
   uint16_t descriptorSize = 0;
 
-  uint8_t protocol;
+  uint8_t protocol = HID_REPORT_PROTOCOL;
   uint8_t idle = 1;
 };
 

--- a/libraries/HID/src/HID.h
+++ b/libraries/HID/src/HID.h
@@ -107,7 +107,7 @@ private:
   uint8_t epType[1];
 
   HIDSubDescriptor* rootNode;
-  uint16_t descriptorSize;
+  uint16_t descriptorSize = 0;
 
   uint8_t protocol;
   uint8_t idle;

--- a/libraries/HID/src/HID.h
+++ b/libraries/HID/src/HID.h
@@ -110,7 +110,7 @@ private:
   uint16_t descriptorSize = 0;
 
   uint8_t protocol;
-  uint8_t idle;
+  uint8_t idle = 1;
 };
 
 // Replacement for global singleton.


### PR DESCRIPTION
Adopt C++11 support for initializing class members directly in the header for improved readability.

I'm willing to also submit PR's for also updating the corresponding implementation in the other Arduino repos (ArduinoCore-samd, ArduinoCore-sam) if desired.

I can also modernize `NULL` usage with the C++11 `nullptr` keyword if there's interest. Haven't done that yet though.