### PR TITLE
Replace strcpy by memcpy on String::concat(const char*, uint32_t);

### DIFF
--- a/cores/arduino/WString.cpp
+++ b/cores/arduino/WString.cpp
@@ -266,7 +266,7 @@ unsigned char String::concat(const char *cstr, unsigned int length)
 	if (!cstr) return 0;
 	if (length == 0) return 1;
 	if (!reserve(newlen)) return 0;
-	strlcpy(buffer + len, cstr, length);
+	memcpy(buffer + len, cstr, length);
 	len = newlen;
 	return 1;
 }


### PR DESCRIPTION
That PR come from with the issues #590 , where I explain in details why strcpy is not safe.