### PR TITLE
Fix sized delete unused parameter warnings

### DIFF
--- a/cores/arduino/new.cpp
+++ b/cores/arduino/new.cpp
@@ -92,10 +92,10 @@ void operator delete[](void * ptr) noexcept {
 }
 
 #if __cplusplus >= 201402L
-void operator delete(void* ptr, std::size_t size) noexcept {
+void operator delete(void* ptr, [[gnu::unused]] std::size_t size) noexcept {
   operator delete(ptr);
 }
-void operator delete[](void * ptr, std::size_t size) noexcept {
+void operator delete[](void * ptr, [[gnu::unused]] std::size_t size) noexcept {
   operator delete[](ptr);
 }
 #endif // __cplusplus >= 201402L


### PR DESCRIPTION
## Problem

Compiling the AVR core with `-Wunused-parameter` reports warnings for the `size` parameter in the C++14 sized `operator delete` overloads.

## Root cause

The sized delete overloads only need the `size` parameter for overload selection; the implementation delegates to the unsized delete overloads and intentionally does not use the value.

## Solution

Mark the two sized delete `size` parameters with `[[gnu::unused]]`, matching the explicit unused-parameter style already preferred for this file's warning fixes.

Fixes #623.

## Tests

- `g++ -std=gnu++14 -Wall -Wextra -c cores/arduino/new.cpp -Icores/arduino -o %TEMP%/arduino-new-after.o` and verified the reported `unused parameter 'size'` warnings are gone
- `git diff --check`